### PR TITLE
pkg/achclient: Add a quick proof of making requests over to ach service

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,6 +2,6 @@
 // Use of this source code is governed by an Apache License
 // license that can be found in the LICENSE file.
 
-package main
+package version
 
 const Version = "v0.1.0-dev"

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/moov-io/auth/admin"
+	"github.com/moov-io/paygate/pkg/achclient"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics/prometheus"
@@ -45,6 +46,14 @@ func main() {
 	logger = log.NewLogfmtLogger(os.Stderr)
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
+
+	// Create ACH client
+	achClient := achclient.New("ach", logger)
+	if err := achClient.Ping(); err != nil {
+		panic(fmt.Sprintf("unable to ping ACH service: %v", err))
+	} else {
+		logger.Log("ach", "Pong successful to ACH service")
+	}
 
 	// Create HTTP handler
 	handler := mux.NewRouter()

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/moov-io/auth/admin"
+	"github.com/moov-io/paygate/internal/version"
 	"github.com/moov-io/paygate/pkg/achclient"
 
 	"github.com/go-kit/kit/log"
@@ -46,6 +47,8 @@ func main() {
 	logger = log.NewLogfmtLogger(os.Stderr)
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
+
+	logger.Log("startup", fmt.Sprintf("Starting paygate server version %s", version.Version))
 
 	// Create ACH client
 	achClient := achclient.New("ach", logger)

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell grep -Eo '(v[0-9]+[\.][0-9]+[\.][0-9]+(-[a-zA-Z0-9]*)?)' version.go)
+VERSION := $(shell grep -Eo '(v[0-9]+[\.][0-9]+[\.][0-9]+(-[a-zA-Z0-9]*)?)' internal/version/version.go)
 
 .PHONY: build docker release
 

--- a/pkg/achclient/client.go
+++ b/pkg/achclient/client.go
@@ -1,0 +1,112 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package achclient
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+var (
+	// achEndpoint is a DNS record responsible for routing us to an ACH instance.
+	// Example: http://ach.apps.svc.cluster.local:8080/
+	//
+	// If running paygate and ACH with our deployment (i.e. in an apps namespace)
+	// you shouldn't need to specify this.
+	achEndpoint = os.Getenv("ACH_ENDPOINT")
+
+	achHttpClient = &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 100,
+			MaxConnsPerHost:     100,
+			IdleConnTimeout:     1 * time.Minute,
+		},
+	}
+
+	// kubernetes service account filepath (on default config)
+	// https://stackoverflow.com/a/49045575
+	k8sServiceAccountFilepath = "/var/run/secrets/kubernetes.io"
+)
+
+// TODO(adam): use go-kit's wrappers and circuit breaker
+// https://godoc.org/github.com/go-kit/kit/transport/http#NewClient
+
+// New creates and returns an ACH instance. This instance can make
+func New(requestId string, logger log.Logger) *ACH {
+	addr := achEndpoint
+	if addr == "" {
+		if _, err := os.Stat(k8sServiceAccountFilepath); err == nil {
+			// We're inside a k8s cluster
+			addr = "http://ach.apps.svc.cluster.local:8080/"
+		} else {
+			// Local development
+			addr = "http://localhost:8080/"
+		}
+	}
+	return &ACH{
+		client:    achHttpClient,
+		endpoint:  addr,
+		logger:    logger,
+		requestId: requestId,
+	}
+}
+
+type ACH struct {
+	client   *http.Client
+	endpoint string
+
+	logger log.Logger
+
+	// X-Request-Id header // TODO(adam): add this on every request
+	requestId string
+}
+
+func (a *ACH) Ping() error {
+	resp, err := a.GET("/ping")
+	if err != nil {
+		return fmt.Errorf("error getting /ping from ACH service: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// parse content-length header
+	n, err := strconv.Atoi(resp.Header.Get("Content-Length"))
+	if err != nil {
+		return fmt.Errorf("error parsing ACH service /ping response: %v", err)
+	}
+	if n > 0 {
+		return nil
+	}
+	return fmt.Errorf("no /ping response from ACH")
+}
+
+func (a *ACH) GET(relPath string) (*http.Response, error) {
+	return a.client.Get(a.buildAddress(relPath))
+}
+
+// buildAddress takes a.endpoint's path and joins it with path to use
+// as the full URL for an http.Client request.
+//
+// This is to handle differences in k8s and local dev. (i.e. /v1/ach/)
+func (a *ACH) buildAddress(p string) string {
+	u, err := url.Parse(a.endpoint)
+	if err != nil {
+		return ""
+	}
+	if u.Scheme == "" {
+		a.logger.Log("ach", fmt.Sprintf("invalid endpoint=%s", u.String()))
+		return ""
+	}
+	u.Path = path.Join(u.Path, p)
+	return u.String()
+}

--- a/pkg/achclient/client_test.go
+++ b/pkg/achclient/client_test.go
@@ -7,11 +7,12 @@ package achclient
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
-	"strings"
 )
 
 var (
@@ -78,5 +79,28 @@ func TestACH__addRequestHeaders(t *testing.T) {
 	}
 	if v := req.Header.Get("X-Request-Id"); v == "" {
 		t.Error("empty header value")
+	}
+}
+
+func TestACH__retryWait(t *testing.T) {
+	neg := -1 * time.Millisecond
+	var cases = map[int]time.Duration{
+		-99: neg,
+		-1:  neg,
+		0:   10 * time.Millisecond,
+		1:   15 * time.Millisecond,
+		2:   25 * time.Millisecond,
+		3:   45 * time.Millisecond,
+		4:   85 * time.Millisecond,
+		5:   125 * time.Millisecond,
+		6:   neg,
+		100: neg,
+	}
+	ach := New("retryWait", log.NewNopLogger())
+	for n, expected := range cases {
+		ans := ach.retryWait(n)
+		if expected != ans {
+			t.Errorf("n=%d, got %s, but expected %s", n, ans, expected)
+		}
 	}
 }

--- a/pkg/achclient/client_test.go
+++ b/pkg/achclient/client_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
+	"strings"
 )
 
 var (
@@ -64,5 +65,18 @@ func TestACH__buildAddress(t *testing.T) {
 	achClient.endpoint = "https://api.moov.io/v1/ach"
 	if v := achClient.buildAddress("/ping"); v != "https://api.moov.io/v1/ach/ping" {
 		t.Errorf("got %q", v)
+	}
+}
+
+func TestACH__addRequestHeaders(t *testing.T) {
+	req := httptest.NewRequest("GET", "/ping", nil)
+	api := New("addRequestHeaders", log.NewNopLogger())
+	api.addRequestHeaders(req)
+
+	if v := req.Header.Get("User-Agent"); !strings.HasPrefix(v, "ach/") {
+		t.Errorf("got %q", v)
+	}
+	if v := req.Header.Get("X-Request-Id"); v == "" {
+		t.Error("empty header value")
 	}
 }

--- a/pkg/achclient/client_test.go
+++ b/pkg/achclient/client_test.go
@@ -1,0 +1,68 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package achclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gorilla/mux"
+)
+
+var (
+	addPingRoute = func(r *mux.Router) {
+		r.Methods("GET").Path("/ping").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("PONG"))
+			w.WriteHeader(http.StatusOK)
+		})
+	}
+)
+
+func newACHWithClientServer(name string, routes ...func(*mux.Router)) (*ACH, *http.Client, *httptest.Server) {
+	r := mux.NewRouter()
+	for i := range routes {
+		routes[i](r) // Add each route
+	}
+	server := httptest.NewServer(r)
+	client := server.Client()
+
+	achClient := New(name, log.NewNopLogger())
+	achClient.client = client
+	achClient.endpoint = server.URL
+
+	return achClient, client, server
+}
+
+func TestACH__pingRoute(t *testing.T) {
+	achClient, _, server := newACHWithClientServer("pingRoute", addPingRoute)
+	defer server.Close()
+
+	// Make our ping request
+	if err := achClient.Ping(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestACH__buildAddress(t *testing.T) {
+	achClient := &ACH{
+		endpoint: "http://localhost:8080",
+	}
+	if v := achClient.buildAddress("/ping"); v != "http://localhost:8080/ping" {
+		t.Errorf("got %q", v)
+	}
+
+	achClient.endpoint = "http://localhost:8080/"
+	if v := achClient.buildAddress("/ping"); v != "http://localhost:8080/ping" {
+		t.Errorf("got %q", v)
+	}
+
+	achClient.endpoint = "https://api.moov.io/v1/ach"
+	if v := achClient.buildAddress("/ping"); v != "https://api.moov.io/v1/ach/ping" {
+		t.Errorf("got %q", v)
+	}
+}


### PR DESCRIPTION
I'm unsure if we want to wrap this in a go-kit circuit breaker as inside k8s we only have the one endpoint.

Issue: https://github.com/moov-io/paygate/issues/8  