### PR TITLE
build: switch back to running as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
 FROM golang:1.11-stretch as builder
 WORKDIR /go/src/github.com/moov-io/paygate
 RUN apt-get update && apt-get install make gcc g++
-RUN adduser -q --gecos '' --disabled-login --shell /bin/false moov
 COPY . .
 RUN make build
-USER moov
 
 FROM debian:9
 RUN apt-get update && apt-get install -y ca-certificates
 COPY --from=builder /go/src/github.com/moov-io/paygate/bin/paygate /bin/paygate
-COPY --from=builder /etc/passwd /etc/passwd
-USER moov
+
 VOLUME "/data"
+ENV SQLITE_DB_PATH /data/paygate.db
+# RUN adduser -q --gecos '' --disabled-login --shell /bin/false moov
+# RUN chown -R moov: /data
+# USER moov
+
 EXPOSE 8080
 EXPOSE 9090
 ENTRYPOINT ["/bin/paygate"]


### PR DESCRIPTION
The container isn't able to access the data volume and fail to
boot. For now I'm reverting the "run as non-root user" change.

Issue: https://github.com/moov-io/infra/issues/25