### PR TITLE
ping and log against ACH and OFAC rather than panic on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,16 +88,24 @@ func main() {
 
 	// Create ACH client
 	achClient := achclient.New("ach", logger)
+	if achClient == nil {
+		panic("no ACH client created")
+	}
 	if err := achClient.Ping(); err != nil {
-		panic(fmt.Sprintf("unable to ping ACH service: %v", err))
+		logger.Log("main", fmt.Sprintf("unable to ping ACH service: %v", err))
 	} else {
-		logger.Log("ach", "Pong successful to ACH service")
+		logger.Log("main", "SUCCESS: ping ACH")
 	}
 
 	// Create OFAC client
 	ofacClient := ofacClient(logger)
 	if ofacClient == nil {
-		panic(fmt.Sprintf("no OFAC client created"))
+		panic("no OFAC client created")
+	}
+	if err := ofacClient.Ping(); err != nil {
+		logger.Log("main", fmt.Sprintf("unable to ping OFAC service: %v", err))
+	} else {
+		logger.Log("main", "SUCCESS: ping OFAC")
 	}
 
 	// Create HTTP handler

--- a/ofac_test.go
+++ b/ofac_test.go
@@ -25,6 +25,10 @@ type testOFACClient struct {
 	err error
 }
 
+func (c *testOFACClient) Ping() error {
+	return c.err
+}
+
 func (c *testOFACClient) GetCompany(_ context.Context, id string) (*ofac.OfacCompany, error) {
 	if c.err != nil {
 		return nil, c.err
@@ -66,6 +70,25 @@ func TestOFAC__matchThreshold(t *testing.T) {
 func TestOFAC__client(t *testing.T) {
 	if client := ofacClient(log.NewNopLogger()); client == nil {
 		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestOFAC_ping(t *testing.T) {
+	client := &testOFACClient{}
+
+	// Ping tests
+	if err := client.Ping(); err != nil {
+		t.Error("expected no error")
+	}
+
+	// set error and verify we get it
+	client.err = errors.New("ping error")
+	if err := client.Ping(); err == nil {
+		t.Error("expected error")
+	} else {
+		if !strings.Contains(err.Error(), "ping error") {
+			t.Errorf("unknown error: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
We'll integrate proper health checks, but `panic`'ing on startup is an anti-pattern so let's get rid of that. 

Issue: https://github.com/moov-io/paygate/issues/50