### PR TITLE
Save micro-deposit fileIds in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,19 @@ ts=2018-12-13T19:18:11.975177Z caller=main.go:124 admin="listening on :9092"
 ### Configuration
 
 - `ACH_ENDPOINT`: DNS record responsible for routing us to an ACH instance. If running as part of our local development setup (or in a Kubernetes cluster we setup) you won't need to set this.
+- `OFAC_ENDPOINT`: HTTP address for HTTP client, defaults to Kubernetes inside clusters and local dev otherwise.
+- `OFAC_MATCH_THRESHOLD`: Percent match against OFAC data that's required for paygate to block a transaction.
+- `SQLITE_DB_PATH`: Local filepath location for the paygate SQLite database.
+
+#### Micro Deposits
+
+In order to validate `Depositories` and transfer money paygate must submit small deposits and credits and have someone confirm the amounts manually. This is only required once per `Depository`. The configuration options for paygate are below and are all required:
+
 - `ODFI_ACCOUNT_NUMBER`: Account Number of Financial Institution which is originating micro deposits.
 - `ODFI_BANK_NAME`: Legal name of Financial Institution which is originating micro deposits.
 - `ODFI_HOLDER`: Legal name of Financial Institution which is originating micro deposits.
 - `ODFI_IDENTIFICATION`: Number by which the customer is known to the Financial Institution originating micro deposits.
 - `ODFI_ROUTING_NUMBER`: ABA routing number of Financial Institution which is originating micro deposits.
-- `OFAC_ENDPOINT`: HTTP address for HTTP client, defaults to Kubernetes inside clusters and local dev otherwise.
-- `OFAC_MATCH_THRESHOLD`: Percent match against OFAC data that's required for paygate to block a transaction.
-- `SQLITE_DB_PATH`: Local filepath location for the paygate SQLite database.
 
 ## Getting Help
 

--- a/database.go
+++ b/database.go
@@ -24,7 +24,7 @@ var (
 
 		// Depositories
 		`create table if not exists depositories(depository_id primary key, user_id, bank_name, holder, holder_type, type, routing_number, account_number, status, metadata, created_at datetime, last_updated_at datetime, deleted_at datetime);`,
-		`create table if not exists micro_deposits(depository_id, user_id, amount, created_at datetime, deleted_at datetime);`,
+		`create table if not exists micro_deposits(depository_id, user_id, amount, file_id, created_at datetime, deleted_at datetime);`,
 
 		// Events
 		`create table if not exists events(event_id primary key, user_id, topic, message, type, created_at datetime);`,

--- a/depositories.go
+++ b/depositories.go
@@ -453,7 +453,8 @@ type depositoryRepository interface {
 	upsertUserDepository(userId string, dep *Depository) error
 	deleteUserDepository(id DepositoryID, userId string) error
 
-	initiateMicroDeposits(id DepositoryID, userId string, amounts []Amount) error
+	getMicroDeposits(id DepositoryID, userId string) ([]microDeposit, error)
+	initiateMicroDeposits(id DepositoryID, userId string, microDeposit []microDeposit) error
 	confirmMicroDeposits(id DepositoryID, userId string, amounts []Amount) error
 }
 

--- a/microDeposits_test.go
+++ b/microDeposits_test.go
@@ -43,7 +43,13 @@ func TestMicroDeposits__repository(t *testing.T) {
 	}
 
 	// write deposits
-	if err := r.initiateMicroDeposits(id, userId, fixedMicroDepositAmounts); err != nil {
+	var microDeposits []microDeposit
+	for i := range fixedMicroDepositAmounts {
+		microDeposits = append(microDeposits, microDeposit{
+			amount: fixedMicroDepositAmounts[i],
+		})
+	}
+	if err := r.initiateMicroDeposits(id, userId, microDeposits); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Right now this information is only kept in logs, which makes any auditing infeasible. 