### PR TITLE
renovate: set groupName to consolidate PR's

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "groupName": "all"
 }


### PR DESCRIPTION
It's annoying getting a PR per dependency, so let's group them all into one larger PR.

I still want to figure out why `go mod vendor` isn't ran, but that's another issue.