### PR TITLE
transfers: process returned files and update their status

### DIFF
--- a/common.go
+++ b/common.go
@@ -77,6 +77,12 @@ func (a Amount) Equal(other Amount) bool {
 	return a.String() != other.String()
 }
 
+// NewAmountFromInt returns an Amount object after converting an integer amount (in cents)
+// and validating the ISO 4217 currency symbol.
+func NewAmountFromInt(symbol string, number int) (*Amount, error) {
+	return NewAmount(symbol, fmt.Sprintf("%.2f", float64(number)/100.0))
+}
+
 // NewAmount returns an Amount object after validating the ISO 4217 currency symbol.
 func NewAmount(symbol string, number string) (*Amount, error) {
 	var amt Amount

--- a/common.go
+++ b/common.go
@@ -190,3 +190,11 @@ func try(f func() error, t time.Duration) error {
 		return errTimeout
 	}
 }
+
+// startOfDayAndTomorrow returns two time.Time values from a given time.Time value.
+// The first is at the start of the same day as provided and the second is exactly 24 hours
+// after the first.
+func startOfDayAndTomorrow(in time.Time) (time.Time, time.Time) {
+	start := in.Truncate(24 * time.Hour)
+	return start, start.Add(24 * time.Hour)
+}

--- a/common_test.go
+++ b/common_test.go
@@ -72,6 +72,15 @@ func TestAmount(t *testing.T) {
 	}
 }
 
+func TestAmount__NewAmountFromInt(t *testing.T) {
+	if amt, _ := NewAmountFromInt("USD", 1266); amt.String() != "USD 12.66" {
+		t.Errorf("got %q", amt.String())
+	}
+	if amt, _ := NewAmountFromInt("USD", 4112); amt.String() != "USD 41.12" {
+		t.Errorf("got %q", amt.String())
+	}
+}
+
 func TestAmount__Int(t *testing.T) {
 	amt, _ := NewAmount("USD", "12.53")
 	if v := amt.Int(); v != 1253 {

--- a/common_test.go
+++ b/common_test.go
@@ -183,3 +183,19 @@ func TestTry(t *testing.T) {
 		t.Errorf("%v was over %v", diff, limit)
 	}
 }
+
+func TestStartOfDayAndTomorrow(t *testing.T) {
+	now := time.Now()
+	min, max := startOfDayAndTomorrow(now)
+
+	if !min.Before(now) {
+		t.Errorf("min=%v now=%v", min, now)
+	}
+	if !max.After(now) {
+		t.Errorf("max=%v now=%v", max, now)
+	}
+
+	if v := max.Sub(min); v != 24*time.Hour {
+		t.Errorf("max - min = %v", v)
+	}
+}

--- a/database.go
+++ b/database.go
@@ -37,6 +37,8 @@ var (
 		// Transfers
 		`create table if not exists transfers(transfer_id, user_id, type, amount, originator_id, originator_depository, receiver, receiver_depository, description, standard_entry_class_code, status, same_day, file_id, merged_filename, created_at datetime, last_updated_at datetime, deleted_at datetime);`,
 		`alter table transfers add column transaction_id;`,
+		`alter table transfers add column return_code;`,
+		`alter table transfers add column trace_number;`,
 
 		// File Merging and Uploading
 		`create table if not exists cutoff_times(routing_number, cutoff, location);`,

--- a/database.go
+++ b/database.go
@@ -36,9 +36,6 @@ var (
 
 		// Transfers
 		`create table if not exists transfers(transfer_id, user_id, type, amount, originator_id, originator_depository, receiver, receiver_depository, description, standard_entry_class_code, status, same_day, file_id, merged_filename, created_at datetime, last_updated_at datetime, deleted_at datetime);`,
-		`alter table transfers add column transaction_id;`,
-		`alter table transfers add column return_code;`,
-		`alter table transfers add column trace_number;`,
 
 		// File Merging and Uploading
 		`create table if not exists cutoff_times(routing_number, cutoff, location);`,

--- a/database.go
+++ b/database.go
@@ -37,6 +37,7 @@ var (
 		// Transfers
 		`create table if not exists transfers(transfer_id, user_id, type, amount, originator_id, originator_depository, receiver, receiver_depository, description, standard_entry_class_code, status, same_day, file_id, merged_filename, created_at datetime, last_updated_at datetime, deleted_at datetime);`,
 		`alter table transfers add column transaction_id;`,
+		`alter table transfers add column trace_number;`,
 
 		// File Merging and Uploading
 		`create table if not exists cutoff_times(routing_number, cutoff, location);`,

--- a/database.go
+++ b/database.go
@@ -35,10 +35,8 @@ var (
 		`create table if not exists receivers(receiver_id priary key, user_id, email, default_depository, status, metadata, created_at datetime, last_updated_at datetime, deleted_at datetime);`,
 
 		// Transfers
-		`create table if not exists transfers(transfer_id, user_id, type, amount, originator_id, originator_depository, receiver, receiver_depository, description, standard_entry_class_code, status, same_day, file_id, merged_filename, created_at datetime, last_updated_at datetime, deleted_at datetime);`,
-		`alter table transfers add column transaction_id;`,
-		`alter table transfers add column return_code;`,
-		`alter table transfers add column trace_number;`,
+		`create table if not exists transfers(transfer_id, user_id, type, amount, originator_id, originator_depository, receiver, receiver_depository, description, standard_entry_class_code, status, same_day, file_id, transaction_id, merged_filename, return_code, trace_number, created_at datetime, last_updated_at datetime, deleted_at datetime);`,
+		// `alter table transfers add column trace_number;`, // TODO(adam): we need to support conditional 'alter table' migrations
 
 		// File Merging and Uploading
 		`create table if not exists cutoff_times(routing_number, cutoff, location);`,

--- a/database.go
+++ b/database.go
@@ -37,7 +37,6 @@ var (
 		// Transfers
 		`create table if not exists transfers(transfer_id, user_id, type, amount, originator_id, originator_depository, receiver, receiver_depository, description, standard_entry_class_code, status, same_day, file_id, merged_filename, created_at datetime, last_updated_at datetime, deleted_at datetime);`,
 		`alter table transfers add column transaction_id;`,
-		`alter table transfers add column trace_number;`,
 
 		// File Merging and Uploading
 		`create table if not exists cutoff_times(routing_number, cutoff, location);`,

--- a/database.go
+++ b/database.go
@@ -36,6 +36,9 @@ var (
 
 		// Transfers
 		`create table if not exists transfers(transfer_id, user_id, type, amount, originator_id, originator_depository, receiver, receiver_depository, description, standard_entry_class_code, status, same_day, file_id, merged_filename, created_at datetime, last_updated_at datetime, deleted_at datetime);`,
+		`alter table transfers add column transaction_id;`,
+		`alter table transfers add column return_code;`,
+		`alter table transfers add column trace_number;`,
 
 		// File Merging and Uploading
 		`create table if not exists cutoff_times(routing_number, cutoff, location);`,

--- a/depositories_test.go
+++ b/depositories_test.go
@@ -26,6 +26,9 @@ type mockDepositoryRepository struct {
 	depositories  []*Depository
 	microDeposits []microDeposit
 	err           error
+
+	// Updated fields
+	status DepositoryStatus
 }
 
 func (r *mockDepositoryRepository) getUserDepositories(userId string) ([]*Depository, error) {
@@ -50,6 +53,7 @@ func (r *mockDepositoryRepository) upsertUserDepository(userId string, dep *Depo
 }
 
 func (r *mockDepositoryRepository) updateDepositoryStatus(id DepositoryID, status DepositoryStatus) error {
+	r.status = status
 	return r.err
 }
 

--- a/depositories_test.go
+++ b/depositories_test.go
@@ -344,9 +344,9 @@ func TestDepositories__updateDepositoryStatus(t *testing.T) {
 
 	r := &sqliteDepositoryRepo{db.db, log.NewNopLogger()}
 
-	userId := nextID()
+	userId := base.ID()
 	dep := &Depository{
-		ID:            DepositoryID(nextID()),
+		ID:            DepositoryID(base.ID()),
 		BankName:      "bank name",
 		Holder:        "holder",
 		HolderType:    Individual,

--- a/depositories_test.go
+++ b/depositories_test.go
@@ -49,6 +49,10 @@ func (r *mockDepositoryRepository) upsertUserDepository(userId string, dep *Depo
 	return r.err
 }
 
+func (r *mockDepositoryRepository) updateDepositoryStatus(id DepositoryID, status DepositoryStatus) error {
+	return r.err
+}
+
 func (r *mockDepositoryRepository) deleteUserDepository(id DepositoryID, userId string) error {
 	return r.err
 }

--- a/depositories_test.go
+++ b/depositories_test.go
@@ -335,6 +335,49 @@ func TestDepositories__delete(t *testing.T) {
 	}
 }
 
+func TestDepositories__updateDepositoryStatus(t *testing.T) {
+	db, err := createTestSqliteDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.close()
+
+	r := &sqliteDepositoryRepo{db.db, log.NewNopLogger()}
+
+	userId := nextID()
+	dep := &Depository{
+		ID:            DepositoryID(nextID()),
+		BankName:      "bank name",
+		Holder:        "holder",
+		HolderType:    Individual,
+		Type:          Checking,
+		RoutingNumber: "123",
+		AccountNumber: "151",
+		Status:        DepositoryUnverified,
+		Created:       base.NewTime(time.Now().Add(-1 * time.Second)),
+	}
+
+	// write
+	if err := r.upsertUserDepository(userId, dep); err != nil {
+		t.Error(err)
+	}
+
+	// upsert and read back
+	if err := r.updateDepositoryStatus(dep.ID, DepositoryVerified); err != nil {
+		t.Fatal(err)
+	}
+	dep2, err := r.getUserDepository(dep.ID, userId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dep.ID != dep2.ID {
+		t.Errorf("expected=%s got=%s", dep.ID, dep2.ID)
+	}
+	if dep2.Status != DepositoryVerified {
+		t.Errorf("unknown status: %s", dep2.Status)
+	}
+}
+
 func TestDepositories__markApproved(t *testing.T) {
 	db, err := createTestSqliteDB()
 	if err != nil {

--- a/file_transfer_async.go
+++ b/file_transfer_async.go
@@ -390,6 +390,8 @@ func (c *fileTransferController) processReturnEntry(fileHeader ach.FileHeader, h
 	return nil
 }
 
+// TODO(adam): On a return reverse the transactions against GL
+
 // updateTransferFromReturnCode will inspect the ach.ReturnCode and optionally update either the originating or receiving Depository.
 // Updates are performed in cases like: death, account closure, authorization revoked, etc as specified in NACHA return codes.
 func updateTransferFromReturnCode(code *ach.ReturnCode, origDep *Depository, destDep *Depository, depRepo depositoryRepository) error {

--- a/file_transfer_async.go
+++ b/file_transfer_async.go
@@ -384,13 +384,15 @@ func (c *fileTransferController) processReturnEntry(fileHeader ach.FileHeader, h
 	if err := transferRepo.setReturnCode(transfer.ID, returnCode.Code); err != nil {
 		return fmt.Errorf("problem updating ReturnCode transfer=%q: %v", transfer.ID, err)
 	}
-	if err := updateTransferFromReturnCode(returnCode, origDep, destDep, depRepo, transferRepo); err != nil {
+	if err := updateTransferFromReturnCode(returnCode, origDep, destDep, depRepo); err != nil {
 		return fmt.Errorf("problem with updateTransferFromReturnCode transfer=%q: %v", transfer.ID, err)
 	}
 	return nil
 }
 
-func updateTransferFromReturnCode(code *ach.ReturnCode, origDep *Depository, destDep *Depository, depRepo depositoryRepository, transferRepo transferRepository) error {
+// updateTransferFromReturnCode will inspect the ach.ReturnCode and optionally update either the originating or receiving Depository.
+// Updates are performed in cases like: death, account closure, authorization revoked, etc as specified in NACHA return codes.
+func updateTransferFromReturnCode(code *ach.ReturnCode, origDep *Depository, destDep *Depository, depRepo depositoryRepository) error {
 	switch code.Code {
 	case "R02", "R07", "R10":
 		// "Account Closed", "Authorization Revoked by Customer", "Customer Advises Not Authorized"

--- a/file_transfer_async.go
+++ b/file_transfer_async.go
@@ -339,9 +339,10 @@ func (c *fileTransferController) processReturnEntry(fileHeader ach.FileHeader, h
 	}
 
 	// Grab the transfer from our database
-	transfer, userId, err := transferRepo.lookupTransferFromReturn(header.StandardEntryClassCode, entry.Amount, entry.TraceNumber, effectiveEntryDate)
+	amount, _ := NewAmount("USD", fmt.Sprintf("%.2f", float64(entry.Amount)/100.0))
+	transfer, userId, err := transferRepo.lookupTransferFromReturn(header.StandardEntryClassCode, amount, entry.TraceNumber, effectiveEntryDate)
 	if err != nil || transfer == nil || userId == "" {
-		return fmt.Errorf("transfer not found: %v", err)
+		return fmt.Errorf("transfer not found: lookupTransferFromReturn: %v", err)
 	}
 
 	// Match user Depositories to our ACH file (the user needs to have Depositories verified for this file)

--- a/file_transfer_async.go
+++ b/file_transfer_async.go
@@ -339,7 +339,7 @@ func (c *fileTransferController) processReturnEntry(fileHeader ach.FileHeader, h
 	}
 
 	// Grab the transfer from our database
-	amount, _ := NewAmount("USD", fmt.Sprintf("%.2f", float64(entry.Amount)/100.0))
+	amount, _ := NewAmountFromInt("USD", entry.Amount)
 	transfer, userId, err := transferRepo.lookupTransferFromReturn(header.StandardEntryClassCode, amount, entry.TraceNumber, effectiveEntryDate)
 	if err != nil || transfer == nil || userId == "" {
 		return fmt.Errorf("transfer not found: lookupTransferFromReturn: %v", err)

--- a/file_transfer_async.go
+++ b/file_transfer_async.go
@@ -599,7 +599,11 @@ func (c *fileTransferController) mergeGroupableTransfer(mergedDir string, xfer *
 	transfersMerged.With("destination", file.Header.ImmediateDestination, "origin", file.Header.ImmediateOrigin).Add(1)
 
 	// Assume the transfer was merged into mergableFile and so we can update its DB record.
-	if err := transferRepo.markTransferAsMerged(xfer.ID, filepath.Base(mergableFile.filepath)); err != nil {
+	traceNumber := ""
+	if len(file.Batches) > 0 && len(file.Batches[0].GetEntries()) > 0 {
+		traceNumber = file.Batches[0].GetEntries()[0].TraceNumberField()
+	}
+	if err := transferRepo.markTransferAsMerged(xfer.ID, filepath.Base(mergableFile.filepath), traceNumber); err != nil {
 		c.logger.Log("mergeGroupableTransfer", fmt.Sprintf("BAD ERROR - unable to mark transfer %s as merged", xfer.ID))
 		// TODO(adam): This error is bad because we could end up merging the transfer into multiple files (i.e. duplicate it)
 		return nil

--- a/file_transfer_async_test.go
+++ b/file_transfer_async_test.go
@@ -802,4 +802,17 @@ func TestFileTransferController__processReturnEntry(t *testing.T) {
 	if transferRepo.status != TransferReclaimed {
 		t.Errorf("unexpected status: %v", transferRepo.status)
 	}
+
+	// Check quick error conditions
+	depRepo.err = errors.New("bad error")
+	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0], depRepo, transferRepo); err == nil {
+		t.Error("expected error")
+	}
+	depRepo.err = nil
+
+	transferRepo.err = errors.New("bad error")
+	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0], depRepo, transferRepo); err == nil {
+		t.Error("expected error")
+	}
+	transferRepo.err = nil
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1660,6 +1660,7 @@ components:
           enum:
             - unverified
             - verified
+            - rejected
         metadata:
           type: string
           description: Additional meta data to be used for display only

--- a/transfers.go
+++ b/transfers.go
@@ -594,7 +594,12 @@ func (c *transferRouter) getUserTransferEvents() http.HandlerFunc {
 type transferRepository interface {
 	getUserTransfers(userId string) ([]*Transfer, error)
 	getUserTransfer(id TransferID, userId string) (*Transfer, error)
+	updateTransferStatus(id TransferID, status TransferStatus) error
+
 	getFileIdForTransfer(id TransferID, userId string) (string, error)
+
+	lookupTransferFromReturn(sec string, amount int, traceNumber string, effectiveEntryDate time.Time) (*Transfer, string, error)
+	setReturnCode(id TransferID, returnCode string) error
 
 	// getTransferCursor returns a database cursor for Transfer objects that need to be
 	// posted today.
@@ -683,6 +688,18 @@ limit 1`
 	return transfer, nil
 }
 
+func (r *sqliteTransferRepo) updateTransferStatus(id TransferID, status TransferStatus) error {
+	query := `update transfers set status = ? where transfer_id = ? and deleted_at is null`
+	stmt, err := r.db.Prepare(query)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(status, id)
+	return err
+}
+
 func (r *sqliteTransferRepo) getFileIdForTransfer(id TransferID, userId string) (string, error) {
 	query := `select file_id from transfers where transfer_id = ? and user_id = ? and deleted_at is null limit 1;`
 	stmt, err := r.db.Prepare(query)
@@ -698,6 +715,40 @@ func (r *sqliteTransferRepo) getFileIdForTransfer(id TransferID, userId string) 
 		return "", err
 	}
 	return fileId, nil
+}
+
+func (r *sqliteTransferRepo) lookupTransferFromReturn(sec string, amount int, traceNumber string, effectiveEntryDate time.Time) (*Transfer, string, error) {
+	query := `select transfer_id, user_id from transfers
+where standard_entry_class_code = ? and amount = ? and trace_number = ? and created_at > ? and created_at < ? and deleted_at is null limit 1`
+	// TODO(adam): need to check .status == TransferProcessed (and flip that after merge/upload)
+	stmt, err := r.db.Prepare(query)
+	if err != nil {
+		return nil, "", err
+	}
+	defer stmt.Close()
+
+	transferId, userId := "", "" // holders for 'select ..'
+	min, max := startOfDayAndTomorrow(effectiveEntryDate)
+
+	row := stmt.QueryRow(sec, amount, traceNumber, min, max)
+	if err := row.Scan(&transferId, &userId); err != nil {
+		return nil, "", err
+	}
+
+	xfer, err := r.getUserTransfer(TransferID(transferId), userId)
+	return xfer, userId, err
+}
+
+func (r *sqliteTransferRepo) setReturnCode(id TransferID, returnCode string) error {
+	query := `update transfers set return_code = ? where transfer_id = ? and return_code is null and deleted_at is null`
+	stmt, err := r.db.Prepare(query)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(returnCode, id)
+	return err
 }
 
 func (r *sqliteTransferRepo) createUserTransfers(userId string, requests []*transferRequest) ([]*Transfer, error) {

--- a/transfers_test.go
+++ b/transfers_test.go
@@ -74,6 +74,7 @@ func createTestTransferRouter(
 type mockTransferRepository struct {
 	xfer   *Transfer
 	fileId string
+	userId string
 
 	err error
 }
@@ -95,11 +96,26 @@ func (r *mockTransferRepository) getUserTransfer(id TransferID, userId string) (
 	return r.xfer, nil
 }
 
+func (r *mockTransferRepository) updateTransferStatus(id TransferID, status TransferStatus) error {
+	return r.err
+}
+
 func (r *mockTransferRepository) getFileIdForTransfer(id TransferID, userId string) (string, error) {
 	if r.err != nil {
 		return "", r.err
 	}
 	return r.fileId, nil
+}
+
+func (r *mockTransferRepository) lookupTransferFromReturn(sec string, amount int, traceNumber string, effectiveEntryDate time.Time) (*Transfer, string, error) {
+	if r.err != nil {
+		return nil, "", r.err
+	}
+	return r.xfer, r.userId, nil
+}
+
+func (r *mockTransferRepository) setReturnCode(id TransferID, returnCode string) error {
+	return r.err
 }
 
 func (r *mockTransferRepository) getTransferCursor(batchSize int, depRepo depositoryRepository) *transferCursor {

--- a/transfers_test.go
+++ b/transfers_test.go
@@ -77,6 +77,10 @@ type mockTransferRepository struct {
 	userId string
 
 	err error
+
+	// Updated fields
+	returnCode string
+	status     TransferStatus
 }
 
 func (r *mockTransferRepository) getUserTransfers(userId string) ([]*Transfer, error) {
@@ -97,6 +101,7 @@ func (r *mockTransferRepository) getUserTransfer(id TransferID, userId string) (
 }
 
 func (r *mockTransferRepository) updateTransferStatus(id TransferID, status TransferStatus) error {
+	r.status = status
 	return r.err
 }
 
@@ -115,6 +120,7 @@ func (r *mockTransferRepository) lookupTransferFromReturn(sec string, amount *Am
 }
 
 func (r *mockTransferRepository) setReturnCode(id TransferID, returnCode string) error {
+	r.returnCode = returnCode
 	return r.err
 }
 

--- a/transfers_test.go
+++ b/transfers_test.go
@@ -1029,7 +1029,7 @@ func TestTransfers__updateTransferStatus(t *testing.T) {
 	repo := &sqliteTransferRepo{db.db, log.NewNopLogger()}
 
 	amt, _ := NewAmount("USD", "32.92")
-	userId := nextID()
+	userId := base.ID()
 	req := &transferRequest{
 		Type:                   PushTransfer,
 		Amount:                 *amt,
@@ -1121,7 +1121,7 @@ func TestTransfers__lookupTransferFromReturn(t *testing.T) {
 	repo := &sqliteTransferRepo{db.db, log.NewNopLogger()}
 
 	amt, _ := NewAmount("USD", "32.92")
-	userId := nextID()
+	userId := base.ID()
 	req := &transferRequest{
 		Type:                   PushTransfer,
 		Amount:                 *amt,

--- a/transfers_test.go
+++ b/transfers_test.go
@@ -106,7 +106,7 @@ func (r *mockTransferRepository) getTransferCursor(batchSize int, depRepo deposi
 	return nil // TODO?
 }
 
-func (r *mockTransferRepository) markTransferAsMerged(id TransferID, filename string) error {
+func (r *mockTransferRepository) markTransferAsMerged(id TransferID, filename string, traceNumber string) error {
 	return r.err
 }
 
@@ -894,7 +894,7 @@ func TestTransfers_markTransferAsMerged(t *testing.T) {
 	}
 
 	// mark our transfer as merged, so we don't see it (in a new transferCursor we create)
-	if err := transferRepo.markTransferAsMerged(firstBatch[0].ID, "merged-file.ach"); err != nil {
+	if err := transferRepo.markTransferAsMerged(firstBatch[0].ID, "merged-file.ach", "traceNumber"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/transfers_test.go
+++ b/transfers_test.go
@@ -1060,6 +1060,12 @@ func TestTransfers__updateTransferStatus(t *testing.T) {
 }
 
 func TestTransfers__transactionId(t *testing.T) {
+	db, err := createTestSqliteDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.close()
+
 	transferRepo := &sqliteTransferRepo{db.db, log.NewNopLogger()}
 
 	userId := base.ID()


### PR DESCRIPTION
This pull request introduces logic in paygate to parse and process returned ACH files. Typically these indicate an error and should mark the `Transfer` as such while also offering notification to the user about the error. 

Issue: https://github.com/moov-io/paygate/issues/90