### PR TITLE
transfers: check Receiver Depository exists in GL for transfers on the same RoutingNumber

### DIFF
--- a/depositories_test.go
+++ b/depositories_test.go
@@ -21,6 +21,52 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
+type mockDepositoryRepository struct {
+	depositories  []*Depository
+	microDeposits []microDeposit
+	err           error
+}
+
+func (r *mockDepositoryRepository) getUserDepositories(userId string) ([]*Depository, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.depositories, nil
+}
+
+func (r *mockDepositoryRepository) getUserDepository(id DepositoryID, userId string) (*Depository, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if len(r.depositories) > 0 {
+		return r.depositories[0], nil
+	}
+	return nil, nil
+}
+
+func (r *mockDepositoryRepository) upsertUserDepository(userId string, dep *Depository) error {
+	return r.err
+}
+
+func (r *mockDepositoryRepository) deleteUserDepository(id DepositoryID, userId string) error {
+	return r.err
+}
+
+func (r *mockDepositoryRepository) getMicroDeposits(id DepositoryID, userId string) ([]microDeposit, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.microDeposits, nil
+}
+
+func (r *mockDepositoryRepository) initiateMicroDeposits(id DepositoryID, userId string, microDeposit []microDeposit) error {
+	return r.err
+}
+
+func (r *mockDepositoryRepository) confirmMicroDeposits(id DepositoryID, userId string, amounts []Amount) error {
+	return r.err
+}
+
 func TestDepositories__depositoryRequest(t *testing.T) {
 	req := depositoryRequest{}
 	if err := req.missingFields(); err == nil {

--- a/main.go
+++ b/main.go
@@ -164,6 +164,7 @@ func main() {
 		achClientFactory: func(userId string) *achclient.ACH {
 			return achclient.New(userId, logger)
 		},
+		glClient: glClient,
 	}
 	xferRouter.registerRoutes(handler)
 

--- a/originators_test.go
+++ b/originators_test.go
@@ -20,6 +20,39 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
+type mockOriginatorRepository struct {
+	originators []*Originator
+	err         error
+}
+
+func (r *mockOriginatorRepository) getUserOriginators(userId string) ([]*Originator, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.originators, nil
+}
+
+func (r *mockOriginatorRepository) getUserOriginator(id OriginatorID, userId string) (*Originator, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if len(r.originators) > 0 {
+		return r.originators[0], nil
+	}
+	return nil, nil
+}
+
+func (r *mockOriginatorRepository) createUserOriginator(userId string, req originatorRequest) (*Originator, error) {
+	if len(r.originators) > 0 {
+		return r.originators[0], nil
+	}
+	return nil, nil
+}
+
+func (r *mockOriginatorRepository) deleteUserOriginator(id OriginatorID, userId string) error {
+	return r.err
+}
+
 func TestOriginators__read(t *testing.T) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(originatorRequest{

--- a/receivers_test.go
+++ b/receivers_test.go
@@ -21,6 +21,36 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
+type mockReceiverRepository struct {
+	receivers []*Receiver
+	err       error
+}
+
+func (r *mockReceiverRepository) getUserReceivers(userId string) ([]*Receiver, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.receivers, nil
+}
+
+func (r *mockReceiverRepository) getUserReceiver(id ReceiverID, userId string) (*Receiver, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if len(r.receivers) > 0 {
+		return r.receivers[0], nil
+	}
+	return nil, nil
+}
+
+func (r *mockReceiverRepository) upsertUserReceiver(userId string, receiver *Receiver) error {
+	return r.err
+}
+
+func (r *mockReceiverRepository) deleteUserReceiver(id ReceiverID, userId string) error {
+	return r.err
+}
+
 func TestReceiverStatus__json(t *testing.T) {
 	cs := ReceiverStatus("invalid")
 	valid := map[string]ReceiverStatus{


### PR DESCRIPTION
When there's a transfer moving funds between the same routing number we need to ensure the receiver's account exists in GL. (The originator is checked on Originator creation.) This helps ensure the account is valid. 

In a later PR we need to submit the transaction against GL prior to Transfer creation. 