### PR TITLE
ofac: search: set match percent on SDN if an AltName overrides it

### DIFF
--- a/ofac_test.go
+++ b/ofac_test.go
@@ -131,6 +131,35 @@ func TestOFAC__client(t *testing.T) {
 	deployment.close(t) // close only if successful
 }
 
+func TestOFAC__get(t *testing.T) {
+	ctx := context.TODO()
+
+	deployment := spawnOFAC(t)
+	customer, err := deployment.client.GetCustomer(ctx, "22790")
+	if customer == nil || err != nil {
+		t.Errorf("customer=%v err=%v", customer, err)
+	}
+
+	company, err := deployment.client.GetCompany(ctx, "22905")
+	if company == nil || err != nil {
+		t.Errorf("company=%v err=%v", company, err)
+	}
+
+	deployment.close(t) // only if rest of test was successful
+
+	// error cases
+	client := newOFACClient(log.NewNopLogger(), "http://localhost:9999")
+
+	customer, err = client.GetCustomer(ctx, "100000")
+	if customer != nil || err == nil {
+		t.Errorf("expected error: customer=%v err=%v", customer, err)
+	}
+	company, err = client.GetCompany(ctx, "100000")
+	if company != nil || err == nil {
+		t.Errorf("expected error: company=%v err=%v", company, err)
+	}
+}
+
 func TestOFAC__search(t *testing.T) {
 	ctx := context.TODO()
 


### PR DESCRIPTION
I was seeing log lines like the following:

```
ts=2019-04-30T19:57:38.130155Z caller=ofac.go:174 customers="ofac: found SDN 11375 with match 0.00 (Jane Doe)" userId=0719d201c83bd7b856333cf498c8c83e89cf268f
```

This doesn't make sense and so we need to set the match percent (as paygate needs that for blocking) and log about it.  