### PR TITLE
receivers: pass emails through net/mail.ParseAddress

### DIFF
--- a/receivers_test.go
+++ b/receivers_test.go
@@ -401,6 +401,32 @@ func TestReceivers_OFACMatch(t *testing.T) {
 	check(t, mysqlDB.DB)
 }
 
+func TestReceivers__parseAndValidateEmail(t *testing.T) {
+	if addr, err := parseAndValidateEmail("a@foo.com"); addr != "a@foo.com" || err != nil {
+		t.Errorf("addr=%s error=%v", addr, err)
+	}
+	if addr, err := parseAndValidateEmail("a+bar@foo.com"); addr != "a+bar@foo.com" || err != nil {
+		t.Errorf("addr=%s error=%v", addr, err)
+	}
+	if addr, err := parseAndValidateEmail(`"a b"@foo.com`); addr != `a b@foo.com` || err != nil {
+		t.Errorf("addr=%s error=%v", addr, err)
+	}
+	if addr, err := parseAndValidateEmail("Barry Gibbs <bg@example.com>"); addr != "bg@example.com" || err != nil {
+		t.Errorf("addr=%s error=%v", addr, err)
+	}
+
+	// sad path
+	if addr, err := parseAndValidateEmail(""); addr != "" || err == nil {
+		t.Errorf("addr=%s error=%v", addr, err)
+	}
+	if addr, err := parseAndValidateEmail("@"); addr != "" || err == nil {
+		t.Errorf("addr=%s error=%v", addr, err)
+	}
+	if addr, err := parseAndValidateEmail("example.com"); addr != "" || err == nil {
+		t.Errorf("addr=%s error=%v", addr, err)
+	}
+}
+
 func TestReceivers__HTTPGet(t *testing.T) {
 	userId, now := base.ID(), time.Now()
 	rec := &Receiver{


### PR DESCRIPTION
This performs a basic format check on the provided email address and
strips out extra junk that RFC 5322 allows. (i.e. 'Bob <bob@example.com')

We don't validate the hostname or mailbox (by sending an activation
email) and I'm unsure if this should be done in a new service or
not. User signup needs to validate emails also, so it seems either
Auth should perform that task or it should be left up to another service.