### PR TITLE
build: add command for a local FTP server

### DIFF
--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,13 +1,12 @@
 ### Local FTP server
 
-Paygate supports merging and uploading tranfers into ACH files and defaults to a local FTP server. The defaults paygate assumes are defined in `localFileTransferRepository` and you can run an FTP server by installing [`github.com/goftp/server/exampleftpd`](https://github.com/goftp/server/tree/master/exampleftpd) (or similar FTP service).
+Paygate supports merging and uploading tranfers into ACH files and defaults to a local FTP server. The defaults paygate assumes are defined in `localFileTransferRepository` and you can run an FTP server by running Moov's `fsftp` Docker image with `make start-ftp-server`. (This image wraps the [goftp/server](https://github.com/goftp/server/tree/master/exampleftpd) example.)
 
-Running `exampleftpd` can be done with (from paygate's `testdata/ftp-server/` directory):
+Running `moov/fsftp` can be done with (from paygate's `testdata/ftp-server/` directory):
 
 ```
-$ cd testdata/
-
-$ exampleftpd -host 0.0.0.0 -root $(pwd) -user admin -pass 123456
+$ make start-ftp-server
+Using ACH files in testdata/ftp-server for FTP server
 2019/04/29 09:07:29 Starting ftp server on 0.0.0.0:2121
 2019/04/29 09:07:29 Username admin, Password 123456
 2019/04/29 09:07:29   Go FTP Server listening on 2121

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,6 +1,6 @@
 ### Local FTP server
 
-Paygate supports merging and uploading tranfers into ACH files and defaults to a local FTP server. The defaults paygate assumes are defined in `localFileTransferRepository` and you can run an FTP server by running Moov's `fsftp` Docker image with `make start-ftp-server`. (This image wraps the [goftp/server](https://github.com/goftp/server/tree/master/exampleftpd) example.)
+Paygate supports merging and uploading tranfers into ACH files and defaults to a local FTP server. The defaults paygate assumes are defined in `localFileTransferRepository` and you can run an FTP server by running Moov's `fsftp` Docker image with `make start-ftp-server`. This image is [located in moov-io/infra](https://github.com/moov-io/infra/tree/master/images/fsftp).
 
 Running `moov/fsftp` can be done with (from paygate's `testdata/ftp-server/` directory):
 

--- a/file_transfer.go
+++ b/file_transfer.go
@@ -71,10 +71,14 @@ func (agent *ftpFileTransferAgent) close() error {
 
 // newFileTransferAgent returns an FTP implementation of a fileTransferAgent
 func newFileTransferAgent(sftpConf *sftpConfig, conf *fileTransferConfig) (fileTransferAgent, error) {
-	conn, err := ftp.DialTimeout(sftpConf.Hostname, 30*time.Second)
+	timeout := ftp.DialWithTimeout(30 * time.Second)
+	// epsv := ftp.DialWithDisabledEPSV(true) // disable passive mode EPSV
+
+	conn, err := ftp.Dial(sftpConf.Hostname, timeout) // epsv
 	if err != nil {
 		return nil, err
 	}
+
 	if err := conn.Login(sftpConf.Username, sftpConf.Password); err != nil {
 		return nil, err
 	}

--- a/file_transfer.go
+++ b/file_transfer.go
@@ -72,9 +72,9 @@ func (agent *ftpFileTransferAgent) close() error {
 // newFileTransferAgent returns an FTP implementation of a fileTransferAgent
 func newFileTransferAgent(sftpConf *sftpConfig, conf *fileTransferConfig) (fileTransferAgent, error) {
 	timeout := ftp.DialWithTimeout(30 * time.Second)
-	// epsv := ftp.DialWithDisabledEPSV(true) // disable passive mode EPSV
+	epsv := ftp.DialWithDisabledEPSV(false)
 
-	conn, err := ftp.Dial(sftpConf.Hostname, timeout) // epsv
+	conn, err := ftp.Dial(sftpConf.Hostname, timeout, epsv)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/goftp/file-driver v0.0.0-20180502053751-5d604a0fc0c9
 	github.com/goftp/server v0.0.0-20190304020633-eabccc535b5a
 	github.com/gorilla/mux v1.7.2
-	github.com/jlaffaye/ftp v0.0.0-20190427163646-6a014d5e22e6
+	github.com/jlaffaye/ftp v0.0.0-20190522102603-9284a88df536
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/moov-io/accounts v0.3.1-0.20190522191929-18df7fa8fa58
 	github.com/moov-io/ach v0.6.0-rc7.0.20190424165414-c1497c09b16f

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/jlaffaye/ftp v0.0.0-20190427163646-6a014d5e22e6 h1:L8GOc4DyMAj4NyTq5He3pY/tfgLWcgwGXGnan5RWf1A=
 github.com/jlaffaye/ftp v0.0.0-20190427163646-6a014d5e22e6/go.mod h1:lli8NYPQOFy3O++YmYbqVgOcQ1JPCwdOy+5zSjKJ9qY=
+github.com/jlaffaye/ftp v0.0.0-20190522102603-9284a88df536 h1:8JvPsUxoqjvg6BB3wrC+LbfgHOeABzOI7gD0k4bUXc0=
+github.com/jlaffaye/ftp v0.0.0-20190522102603-9284a88df536/go.mod h1:lli8NYPQOFy3O++YmYbqVgOcQ1JPCwdOy+5zSjKJ9qY=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=

--- a/makefile
+++ b/makefile
@@ -48,8 +48,7 @@ test-integration: clean-integration
 
 start-ftp-server:
 	@echo Using ACH files in testdata/ftp-server for FTP server
-	@docker run -p 2121:2121 -v $(shell pwd)/testdata/ftp-server:/data moov/fsftp:v0.1.0 -host 0.0.0.0 -root /data -user admin -pass 123456
-#	docker run -p 2121:21 -p 30000-30009:30000-30009 -v $(shell pwd)/testdata/ftp-server:/home/ftpusers/ -e FTP_USER_NAME=admin -e FTP_USER_PASS=123456 -e FTP_USER_HOME=/home/ftpusers/ stilliard/pure-ftpd:hardened
+	@docker run -p 2121:2121 -p 30000-30009:30000-30009 -v $(shell pwd)/testdata/ftp-server:/data moov/fsftp:v0.2.0 -host 0.0.0.0 -root /data -user admin -pass 123456 -passive-ports 30000-30009
 
 # From https://github.com/genuinetools/img
 .PHONY: AUTHORS

--- a/makefile
+++ b/makefile
@@ -46,6 +46,11 @@ test-integration: clean-integration
 	sleep 5
 	apitest -local
 
+start-ftp-server:
+	@echo Using ACH files in testdata/ftp-server for FTP server
+	@docker run -p 2121:2121 -v $(shell pwd)/testdata/ftp-server:/data moov/fsftp:v0.1.0 -host 0.0.0.0 -root /data -user admin -pass 123456
+#	docker run -p 2121:21 -p 30000-30009:30000-30009 -v $(shell pwd)/testdata/ftp-server:/home/ftpusers/ -e FTP_USER_NAME=admin -e FTP_USER_PASS=123456 -e FTP_USER_HOME=/home/ftpusers/ stilliard/pure-ftpd:hardened
+
 # From https://github.com/genuinetools/img
 .PHONY: AUTHORS
 AUTHORS:


### PR DESCRIPTION
Previously I ran a long magic command to test out paygate's FTP logic. I've shipped a Docker image and bundled the command into `make start-ftp-server` that's easier to distribute. 

Also, I had to mess with (e)passive mode and I'm not completely sure which should be the default in production. I assume we'll have to make EPSV configurable in the future. 