### PR TITLE
files: support 'off' to disable async file operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The following environmental variables can be set to configure behavior in paygat
 
 - `ACH_FILE_BATCH_SIZE`: Number of Transfers to retrieve from the database in each batch for mergin before upload to Fed.
 - `ACH_FILE_TRANSFER_INTERVAL`: Go duration for how often to check and sync ACH files on their SFTP destinations.
+   - Note: Set the value `off` to completely disable async file downloads and uploads.
 - `ACH_FILE_STORAGE_DIR`: Filepath for temporary storage of ACH files. This is used as a scratch directory to manage outbound and incoming/returned ACH files.
 - `FORCED_CUTOFF_UPLOAD_DELTA`: When the current time is within the routing number's cutoff time by duration force that file to be uploaded.
 


### PR DESCRIPTION
This allows paygate's async file operations to be disabled. Previously
paygate would just keep failing to connect to the local dev SFTP
endpoint or any configured ones.