### PR TITLE
internal/database: check driver error types for unique violations

### DIFF
--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -164,5 +164,9 @@ func CreateTestSqliteDB(t *testing.T) *TestSQLiteDB {
 // SqliteUniqueViolation returns true when the provided error matches the SQLite error
 // for duplicate entries (violating a unique table constraint).
 func SqliteUniqueViolation(err error) bool {
-	return strings.Contains(err.Error(), "UNIQUE constraint failed")
+	match := strings.Contains(err.Error(), "UNIQUE constraint failed")
+	if e, ok := err.(sqlite3.Error); ok {
+		return match || e.Code == sqlite3.ErrConstraint
+	}
+	return match
 }


### PR DESCRIPTION
Noticed then when reading through https://github.com/writeas/writefreely/blob/v0.9.1/database-sqlite.go#L36-L50. They handle sqlite and mysql just like paygate. 