### PR TITLE
http: setup http.Client's with additional root certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The following environmental variables can be set to configure behavior in paygat
 - `ACCOUNTS_ENDPOINT`: A DNS record responsible for routing us to an [Accounts](https://github.com/moov-io/accounts) instance. (Example: http://accounts.apps.svc.cluster.local:8080)
   - Set `ACCOUNTS_CALLS_DISABLED=yes` to completely disable all calls to an Accounts service. This is used when paygate doesn't need to integrate with a general ledger solution.
 - `FED_ENDPOINT`: HTTP address for [FED](https://github.com/moov-io/fed) interaction to lookup ABA routing numbers
+- `HTTP_CLIENT_CAFILE`: Filepath for additional (CA) certificates to be added into each `http.Client` used within paygate
 - `OFAC_ENDPOINT`: HTTP address for [OFAC](https://github.com/moov-io/ofac) interaction, defaults to Kubernetes inside clusters and local dev otherwise.
 - `OFAC_MATCH_THRESHOLD`: Percent match against OFAC data that's required for paygate to block a transaction.
 - `DATABASE_TYPE`: Which database option to use (options: `sqlite` [Default], `mysql`)

--- a/accounts.go
+++ b/accounts.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	accounts "github.com/moov-io/accounts/client"
@@ -134,9 +135,10 @@ func (c *moovAccountsClient) ReverseTransaction(requestId, userId string, transa
 //
 // endpoint is a DNS record responsible for routing us to an Account instance.
 // Example: http://accounts.apps.svc.cluster.local:8080
-func createAccountsClient(logger log.Logger, endpoint string) AccountsClient {
+func createAccountsClient(logger log.Logger, endpoint string, httpClient *http.Client) AccountsClient {
 	conf := accounts.NewConfiguration()
 	conf.BasePath = "http://localhost" + bind.HTTP("accounts")
+	conf.HTTPClient = httpClient
 
 	if k8s.Inside() {
 		conf.BasePath = "http://accounts.apps.svc.cluster.local:8080"

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -91,7 +91,8 @@ func spawnAccounts(t *testing.T) *accountsDeployment {
 		t.Fatal(err)
 	}
 
-	client := createAccountsClient(log.NewNopLogger(), fmt.Sprintf("http://localhost:%s", resource.GetPort("8080/tcp")))
+	addr := fmt.Sprintf("http://localhost:%s", resource.GetPort("8080/tcp"))
+	client := createAccountsClient(log.NewNopLogger(), addr, nil)
 	err = pool.Retry(func() error {
 		return client.Ping()
 	})
@@ -103,7 +104,7 @@ func spawnAccounts(t *testing.T) *accountsDeployment {
 
 func TestAccounts__client(t *testing.T) {
 	endpoint := ""
-	if client := createAccountsClient(log.NewNopLogger(), endpoint); client == nil {
+	if client := createAccountsClient(log.NewNopLogger(), endpoint, nil); client == nil {
 		t.Fatal("expected non-nil client")
 	}
 

--- a/depositories.go
+++ b/depositories.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moov-io/base"
 	moovhttp "github.com/moov-io/base/http"
 	"github.com/moov-io/paygate/internal/database"
+	"github.com/moov-io/paygate/pkg/achclient"
 
 	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
@@ -194,7 +195,7 @@ func depositoryIdExists(userId string, id DepositoryID, repo depositoryRepositor
 	return dep.ID == id
 }
 
-func addDepositoryRoutes(logger log.Logger, r *mux.Router, fedClient FEDClient, ofacClient OFACClient, depositoryRepo depositoryRepository, eventRepo eventRepository) {
+func addDepositoryRoutes(logger log.Logger, r *mux.Router, achClient *achclient.ACH, fedClient FEDClient, ofacClient OFACClient, depositoryRepo depositoryRepository, eventRepo eventRepository) {
 	r.Methods("GET").Path("/depositories").HandlerFunc(getUserDepositories(logger, depositoryRepo))
 	r.Methods("POST").Path("/depositories").HandlerFunc(createUserDepository(logger, fedClient, ofacClient, depositoryRepo))
 
@@ -202,7 +203,7 @@ func addDepositoryRoutes(logger log.Logger, r *mux.Router, fedClient FEDClient, 
 	r.Methods("PATCH").Path("/depositories/{depositoryId}").HandlerFunc(updateUserDepository(logger, depositoryRepo))
 	r.Methods("DELETE").Path("/depositories/{depositoryId}").HandlerFunc(deleteUserDepository(logger, depositoryRepo))
 
-	r.Methods("POST").Path("/depositories/{depositoryId}/micro-deposits").HandlerFunc(initiateMicroDeposits(logger, depositoryRepo, eventRepo))
+	r.Methods("POST").Path("/depositories/{depositoryId}/micro-deposits").HandlerFunc(initiateMicroDeposits(logger, depositoryRepo, eventRepo, achClient))
 	r.Methods("POST").Path("/depositories/{depositoryId}/micro-deposits/confirm").HandlerFunc(confirmMicroDeposits(logger, depositoryRepo))
 }
 

--- a/depositories_test.go
+++ b/depositories_test.go
@@ -530,7 +530,7 @@ func TestDepositories__HTTPCreate(t *testing.T) {
 	repo := &sqliteDepositoryRepo{db.DB, log.NewNopLogger()}
 
 	router := mux.NewRouter()
-	addDepositoryRoutes(log.NewNopLogger(), router, fedClient, ofacClient, repo, nil)
+	addDepositoryRoutes(log.NewNopLogger(), router, nil, fedClient, ofacClient, repo, nil)
 
 	req := depositoryRequest{
 		BankName:   "bank",
@@ -607,7 +607,7 @@ func TestDepositories__HTTPUpdate(t *testing.T) {
 	}
 
 	router := mux.NewRouter()
-	addDepositoryRoutes(log.NewNopLogger(), router, nil, nil, repo, nil)
+	addDepositoryRoutes(log.NewNopLogger(), router, nil, nil, nil, repo, nil)
 
 	body := strings.NewReader(`{"accountNumber": "251i5219"}`)
 	req := httptest.NewRequest("PATCH", fmt.Sprintf("/depositories/%s", dep.ID), body)
@@ -650,7 +650,7 @@ func TestDepositories__HTTPGet(t *testing.T) {
 	}
 
 	router := mux.NewRouter()
-	addDepositoryRoutes(log.NewNopLogger(), router, nil, nil, repo, nil)
+	addDepositoryRoutes(log.NewNopLogger(), router, nil, nil, nil, repo, nil)
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/depositories/%s", dep.ID), nil)
 	req.Header.Set("x-user-id", userId)

--- a/fed.go
+++ b/fed.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -72,9 +73,10 @@ func (c *moovFEDClient) LookupRoutingNumber(routingNumber string) error {
 	return errors.New("no ACH participants found")
 }
 
-func createFEDClient(logger log.Logger) FEDClient {
+func createFEDClient(logger log.Logger, httpClient *http.Client) FEDClient {
 	conf := fed.NewConfiguration()
 	conf.BasePath = "http://localhost" + bind.HTTP("fed")
+	conf.HTTPClient = httpClient
 
 	if k8s.Inside() {
 		conf.BasePath = "http://fed.apps.svc.cluster.local:8080"

--- a/fed_test.go
+++ b/fed_test.go
@@ -35,7 +35,7 @@ func TestFED(t *testing.T) {
 	}))
 	os.Setenv("FED_ENDPOINT", svc.URL)
 
-	client := createFEDClient(log.NewNopLogger())
+	client := createFEDClient(log.NewNopLogger(), nil)
 	if err := client.Ping(); err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestFED(t *testing.T) {
 	}))
 	os.Setenv("FED_ENDPOINT", svc.URL)
 
-	client = createFEDClient(log.NewNopLogger())
+	client = createFEDClient(log.NewNopLogger(), nil)
 	if err := client.LookupRoutingNumber("121042882"); err != nil {
 		t.Fatal(err)
 	}

--- a/file_transfer_async.go
+++ b/file_transfer_async.go
@@ -121,7 +121,7 @@ type fileTransferController struct {
 // to their SFTP host for processing.
 //
 // To change the refresh duration set ACH_FILE_TRANSFER_INTERVAL with a Go time.Duration value. (i.e. 10m for 10 minutes)
-func newFileTransferController(logger log.Logger, dir string, repo fileTransferRepository, accountsClient AccountsClient, accountsCallsDisabled bool) (*fileTransferController, error) {
+func newFileTransferController(logger log.Logger, dir string, repo fileTransferRepository, achClient *achclient.ACH, accountsClient AccountsClient, accountsCallsDisabled bool) (*fileTransferController, error) {
 	if _, err := os.Stat(dir); dir == "" || err != nil {
 		return nil, fmt.Errorf("file-transfer-controller: problem with storage directory %q: %v", dir, err)
 	}
@@ -173,7 +173,7 @@ func newFileTransferController(logger log.Logger, dir string, repo fileTransferR
 		cutoffTimes:         cutoffTimes,
 		sftpConfigs:         sftpConfigs,
 		fileTransferConfigs: fileTransferConfigs,
-		ach:                 achclient.New("", logger),
+		ach:                 achClient,
 		logger:              logger,
 	}
 	if !accountsCallsDisabled {

--- a/file_transfer_async_test.go
+++ b/file_transfer_async_test.go
@@ -86,7 +86,7 @@ func TestFileTransferController__newFileTransferController(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	repo := &localFileTransferRepository{}
-	controller, err := newFileTransferController(log.NewNopLogger(), dir, repo, nil, true)
+	controller, err := newFileTransferController(log.NewNopLogger(), dir, repo, nil, nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -633,7 +633,7 @@ func TestFileTransferController__processReturnEntry(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "processReturnEntry")
 	defer os.RemoveAll(dir)
 
-	controller, err := newFileTransferController(log.NewNopLogger(), dir, &localFileTransferRepository{}, nil, true)
+	controller, err := newFileTransferController(log.NewNopLogger(), dir, &localFileTransferRepository{}, nil, nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http.go
+++ b/http.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -104,7 +103,7 @@ func cleanMetricsPath(path string) string {
 	return strings.Join(out, "-")
 }
 
-func tlsHttpClient() (*http.Client, error) {
+func tlsHttpClient(path string) (*http.Client, error) {
 	tlsConfig := &tls.Config{}
 	pool, err := x509.SystemCertPool()
 	if pool == nil || err != nil {
@@ -112,7 +111,7 @@ func tlsHttpClient() (*http.Client, error) {
 	}
 
 	// read extra CA file
-	if path := os.Getenv("HTTP_CLIENT_CAFILE"); path != "" {
+	if path != "" {
 		bs, err := ioutil.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("problem reading %s: %v", path, err)

--- a/http_test.go
+++ b/http_test.go
@@ -5,10 +5,17 @@
 package main
 
 import (
+	"bytes"
+	"crypto/tls"
+	"encoding/pem"
 	"errors"
+	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/moov-io/base"
 
@@ -91,5 +98,56 @@ func TestHTTP__cleanMetricsPath(t *testing.T) {
 	// A value which looks like moov/base.ID, but is off by one character (last letter)
 	if v := cleanMetricsPath("/v1/paygate/customers/19636f90bc95779e2488b0f7a45c4b68958a2ddz"); v != "v1-paygate-customers-19636f90bc95779e2488b0f7a45c4b68958a2ddz" {
 		t.Errorf("got %q", v)
+	}
+}
+
+func TestHTTP__tlsHttpClient(t *testing.T) {
+	client, err := tlsHttpClient("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client == nil {
+		t.Error("empty http.Client")
+	}
+
+	if testing.Short() {
+		return // skip network call on -short
+	}
+
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	conn, err := tls.DialWithDialer(dialer, "tcp", "google.com:443", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	defer conn.Close()
+
+	fd, err := ioutil.TempFile("", "tlsHttpClient")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(fd.Name())
+
+	// Write x509 certs to disk
+	certs := conn.ConnectionState().PeerCertificates
+	var buf bytes.Buffer
+	for i := range certs {
+		b := &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certs[i].Raw,
+		}
+		if err := pem.Encode(&buf, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := ioutil.WriteFile(fd.Name(), buf.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err = tlsHttpClient(fd.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client == nil {
+		t.Error("empty http.Client")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -92,15 +92,20 @@ func main() {
 	transferRepo := &sqliteTransferRepo{db, logger}
 	defer transferRepo.close()
 
+	httpClient, err := tlsHttpClient()
+	if err != nil {
+		panic(fmt.Sprintf("problem creating TLS ready *http.Client: %v", err))
+	}
+
 	// Create ACH client
-	achClient := achclient.New("ach", logger)
+	achClient := achclient.New(logger, "ach", httpClient)
 	if achClient == nil {
 		panic("no ACH client created")
 	}
 	adminServer.AddLivenessCheck("ach", achClient.Ping)
 
 	// Create FED client
-	fedClient := createFEDClient(logger)
+	fedClient := createFEDClient(logger, httpClient)
 	if fedClient == nil {
 		panic("no FED client created")
 	}
@@ -110,7 +115,7 @@ func main() {
 	var accountsClient AccountsClient
 	accountsCallsDisabled := yes(os.Getenv("ACCOUNTS_CALLS_DISABLED"))
 	if !accountsCallsDisabled {
-		accountsClient = createAccountsClient(logger, os.Getenv("ACCOUNTS_ENDPOINT"))
+		accountsClient = createAccountsClient(logger, os.Getenv("ACCOUNTS_ENDPOINT"), httpClient)
 		if accountsClient == nil {
 			panic("no Accounts client created")
 		}
@@ -118,7 +123,7 @@ func main() {
 	}
 
 	// Create OFAC client
-	ofacClient := newOFACClient(logger, os.Getenv("OFAC_ENDPOINT"))
+	ofacClient := newOFACClient(logger, os.Getenv("OFAC_ENDPOINT"), httpClient)
 	if ofacClient == nil {
 		panic("no OFAC client created")
 	}
@@ -132,7 +137,7 @@ func main() {
 	}
 	fileTransferRepo := newFileTransferRepository(db, os.Getenv("DATABASE_TYPE"))
 	defer fileTransferRepo.close()
-	fileTransferController, err := newFileTransferController(logger, achStorageDir, fileTransferRepo, accountsClient, accountsCallsDisabled)
+	fileTransferController, err := newFileTransferController(logger, achStorageDir, fileTransferRepo, achClient, accountsClient, accountsCallsDisabled)
 	if err != nil {
 		panic(fmt.Sprintf("ERROR: creating ACH file transfer controller: %v", err))
 	}
@@ -150,7 +155,7 @@ func main() {
 	// Create HTTP handler
 	handler := mux.NewRouter()
 	addReceiverRoutes(logger, handler, ofacClient, receiverRepo, depositoryRepo)
-	addDepositoryRoutes(logger, handler, fedClient, ofacClient, depositoryRepo, eventRepo)
+	addDepositoryRoutes(logger, handler, achClient, fedClient, ofacClient, depositoryRepo, eventRepo)
 	addEventRoutes(logger, handler, eventRepo)
 	addGatewayRoutes(logger, handler, gatewaysRepo)
 	addOriginatorRoutes(logger, handler, accountsCallsDisabled, accountsClient, ofacClient, depositoryRepo, originatorsRepo)
@@ -165,7 +170,7 @@ func main() {
 		transferRepo:       transferRepo,
 
 		achClientFactory: func(userId string) *achclient.ACH {
-			return achclient.New(userId, logger)
+			return achclient.New(logger, userId, httpClient)
 		},
 
 		accountsClient:        accountsClient,

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 	transferRepo := &sqliteTransferRepo{db, logger}
 	defer transferRepo.close()
 
-	httpClient, err := tlsHttpClient()
+	httpClient, err := tlsHttpClient(os.Getenv("HTTP_CLIENT_CAFILE"))
 	if err != nil {
 		panic(fmt.Sprintf("problem creating TLS ready *http.Client: %v", err))
 	}

--- a/microDeposits_test.go
+++ b/microDeposits_test.go
@@ -103,17 +103,17 @@ func TestMicroDeposits__routes(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		handler := mux.NewRouter()
-		fedClient := &testFEDClient{}
-		ofacClient := &testOFACClient{}
-		addDepositoryRoutes(log.NewNopLogger(), handler, fedClient, ofacClient, depRepo, eventRepo)
+		fedClient, ofacClient := &testFEDClient{}, &testOFACClient{}
 
 		// Bring up a test ACH instance
-		_, _, server := achclient.MockClientServer("micro-deposits", func(r *mux.Router) {
+		achClient, _, server := achclient.MockClientServer("micro-deposits", func(r *mux.Router) {
 			achclient.AddCreateRoute(nil, r)
 			achclient.AddValidateRoute(r)
 		})
 		defer server.Close()
+
+		handler := mux.NewRouter()
+		addDepositoryRoutes(log.NewNopLogger(), handler, achClient, fedClient, ofacClient, depRepo, eventRepo)
 
 		// Set ACH_ENDPOINT to override the achclient.New call
 		os.Setenv("ACH_ENDPOINT", server.URL)

--- a/ofac.go
+++ b/ofac.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -136,9 +137,10 @@ func (c *moovOFACClient) Search(ctx context.Context, name string, requestId stri
 //
 // endpoint is a DNS record responsible for routing us to an OFAC instance.
 // Example: http://ofac.apps.svc.cluster.local:8080
-func newOFACClient(logger log.Logger, endpoint string) OFACClient {
+func newOFACClient(logger log.Logger, endpoint string, httpClient *http.Client) OFACClient {
 	conf := ofac.NewConfiguration()
 	conf.BasePath = "http://localhost" + bind.HTTP("ofac")
+	conf.HTTPClient = httpClient
 
 	if k8s.Inside() {
 		conf.BasePath = "http://ofac.apps.svc.cluster.local:8080"

--- a/ofac_test.go
+++ b/ofac_test.go
@@ -106,7 +106,8 @@ func spawnOFAC(t *testing.T) *ofacDeployment {
 		t.Fatal(err)
 	}
 
-	client := newOFACClient(log.NewNopLogger(), fmt.Sprintf("http://localhost:%s", resource.GetPort("8080/tcp")))
+	addr := fmt.Sprintf("http://localhost:%s", resource.GetPort("8080/tcp"))
+	client := newOFACClient(log.NewNopLogger(), addr, nil)
 	err = pool.Retry(func() error {
 		return client.Ping()
 	})
@@ -118,7 +119,7 @@ func spawnOFAC(t *testing.T) *ofacDeployment {
 
 func TestOFAC__client(t *testing.T) {
 	endpoint := ""
-	if client := newOFACClient(log.NewNopLogger(), endpoint); client == nil {
+	if client := newOFACClient(log.NewNopLogger(), endpoint, nil); client == nil {
 		t.Fatal("expected non-nil client")
 	}
 
@@ -147,7 +148,7 @@ func TestOFAC__get(t *testing.T) {
 	deployment.close(t) // only if rest of test was successful
 
 	// error cases
-	client := newOFACClient(log.NewNopLogger(), "http://localhost:9999")
+	client := newOFACClient(log.NewNopLogger(), "http://localhost:9999", nil)
 
 	customer, err = client.GetCustomer(ctx, "100000")
 	if customer != nil || err == nil {

--- a/pkg/achclient/client.go
+++ b/pkg/achclient/client.go
@@ -24,17 +24,6 @@ import (
 )
 
 var (
-	// achHttpClient is an HTTP client that implements retries.
-	achHttpClient = &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			MaxIdleConns:        100,
-			MaxIdleConnsPerHost: 100,
-			MaxConnsPerHost:     100,
-			IdleConnTimeout:     1 * time.Minute,
-		},
-	}
-
 	// kubernetes service account filepath (on default config)
 	// https://stackoverflow.com/a/49045575
 	k8sServiceAccountFilepath = "/var/run/secrets/kubernetes.io"
@@ -46,11 +35,18 @@ var (
 // There is a shared *http.Client used across all instances.
 //
 // If ran inside a Kubernetes cluster then Moov's kube-dns record will be the default endpoint.
-func New(userId string, logger log.Logger) *ACH {
+func New(logger log.Logger, userId string, httpClient *http.Client) *ACH {
 	addr := getACHAddress()
 	logger.Log("ach", fmt.Sprintf("using %s for ACH address", addr))
+
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: 10 * time.Second,
+		}
+	}
+
 	return &ACH{
-		client:   achHttpClient,
+		client:   httpClient,
 		endpoint: addr,
 		logger:   logger,
 		userId:   userId,

--- a/pkg/achclient/client_test.go
+++ b/pkg/achclient/client_test.go
@@ -108,7 +108,7 @@ func TestACH__addRequestHeaders(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api := New("addRequestHeaders", log.NewNopLogger())
+	api := New(log.NewNopLogger(), "addRequestHeaders", nil)
 	api.addRequestHeaders("idempotencyKey", "requestId", req)
 
 	if v := req.Header.Get("User-Agent"); !strings.HasPrefix(v, "ach/") {

--- a/pkg/achclient/mock_client.go
+++ b/pkg/achclient/mock_client.go
@@ -128,7 +128,7 @@ func MockClientServer(name string, routes ...func(*mux.Router)) (*ACH, *http.Cli
 	server := httptest.NewServer(r)
 	client := server.Client()
 
-	achClient := New(name, log.NewNopLogger())
+	achClient := New(log.NewNopLogger(), name, nil)
 	achClient.client = client
 	achClient.endpoint = server.URL
 


### PR DESCRIPTION
This allows private CA's to be added in for internal calls between
paygate and other services over TLS.