### PR TITLE
main: override -log.format with LOG_FORMAT and -http.addr with HTTP_BIND_ADDRESS

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ The following environmental variables can be set to configure behavior in paygat
 - `ACCOUNTS_ENDPOINT`: A DNS record responsible for routing us to an [Accounts](https://github.com/moov-io/accounts) instance. (Example: http://accounts.apps.svc.cluster.local:8080)
   - Set `ACCOUNTS_CALLS_DISABLED=yes` to completely disable all calls to an Accounts service. This is used when paygate doesn't need to integrate with a general ledger solution.
 - `FED_ENDPOINT`: HTTP address for [FED](https://github.com/moov-io/fed) interaction to lookup ABA routing numbers
+- `HTTP_BIND_ADDRESS`: Address for paygate to bind its HTTP server on. This overrides the command-line flag `-http.addr`. (Default: `:8082`)
 - `HTTP_CLIENT_CAFILE`: Filepath for additional (CA) certificates to be added into each `http.Client` used within paygate
+- `LOG_FORMAT`: Format for logging lines to be written as. (Options: `json`, `plain` - Default: `plain`)
 - `OFAC_ENDPOINT`: HTTP address for [OFAC](https://github.com/moov-io/ofac) interaction, defaults to Kubernetes inside clusters and local dev otherwise.
 - `OFAC_MATCH_THRESHOLD`: Percent match against OFAC data that's required for paygate to block a transaction.
 - `DATABASE_TYPE`: Which database option to use (options: `sqlite` [Default], `mysql`)

--- a/main.go
+++ b/main.go
@@ -37,6 +37,9 @@ func main() {
 	flag.Parse()
 
 	var logger log.Logger
+	if v := os.Getenv("LOG_FORMAT"); v != "" {
+		*flagLogFormat = v
+	}
 	if strings.ToLower(*flagLogFormat) == "json" {
 		logger = log.NewJSONLogger(os.Stderr)
 	} else {
@@ -178,6 +181,10 @@ func main() {
 	}
 	xferRouter.registerRoutes(handler)
 
+	// Check to see if our -http.addr flag has been overridden
+	if v := os.Getenv("HTTP_BIND_ADDRESS"); v != "" {
+		*httpAddr = v
+	}
 	// Create main HTTP server
 	serve := &http.Server{
 		Addr:    *httpAddr,
@@ -200,7 +207,7 @@ func main() {
 
 	// Start main HTTP server
 	go func() {
-		logger.Log("transport", "HTTP", "addr", *httpAddr)
+		logger.Log("startup", fmt.Sprintf("binding to %s for HTTP server", *httpAddr))
 		if err := serve.ListenAndServe(); err != nil {
 			logger.Log("main", err)
 		}


### PR DESCRIPTION
```
$ LOG_FORMAT=JSON HTTP_BIND_ADDRESS=:9999 go run . 
{"caller":"main.go:51","startup":"Starting paygate server version v0.6.0-dev","ts":"2019-07-06T23:00:12.628838Z"}
...
{"caller":"main.go:210","startup":"binding to :9999 for HTTP server","ts":"2019-07-06T23:00:12.805433Z"}
```

Fixes: https://github.com/moov-io/paygate/issues/158