### PR TITLE
files: rename 'sftp' to 'ftp' as sftp is an ssh-based file transfer protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## v0.6.0 (Unreleased)
 
+BREAKING CHANGES
+
+- `sftp_configs` has been renamed to `ftp_configs` as it was incorrectly named before.
+  - Users need to copy data and delete the table so paygate can re-create `sftp_configs` for its new purpose.
+
 ADDITIONS
 
 - files: support `ACH_FILE_TRANSFER_INTERVAL=off` to disable async file operations

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ The following environmental variables can be set to configure behavior in paygat
 #### ACH file uploading / transfers
 
 - `ACH_FILE_BATCH_SIZE`: Number of Transfers to retrieve from the database in each batch for mergin before upload to Fed.
-- `ACH_FILE_TRANSFER_INTERVAL`: Go duration for how often to check and sync ACH files on their SFTP destinations.
+- `ACH_FILE_TRANSFER_INTERVAL`: Go duration for how often to check and sync ACH files on their FTP destinations.
    - Note: Set the value `off` to completely disable async file downloads and uploads.
 - `ACH_FILE_STORAGE_DIR`: Filepath for temporary storage of ACH files. This is used as a scratch directory to manage outbound and incoming/returned ACH files.
 - `FORCED_CUTOFF_UPLOAD_DELTA`: When the current time is within the routing number's cutoff time by duration force that file to be uploaded.
 
-See [our detailed documentation for SFTP configurations](docs/ach.md#sftp-uploads-of-merged-ach-files).
+See [our detailed documentation for FTP configurations](docs/ach.md#ftp-uploads-of-merged-ach-files).
 
 #### Micro Deposits
 

--- a/docs/ach.md
+++ b/docs/ach.md
@@ -22,28 +22,28 @@ The code paths for [merging and uploading ACH files is within `fileTransferContr
 
 The [US Federal Reserve](https://en.wikipedia.org/wiki/Federal_Reserve_Bank) has multiple locations where we can have ACH files sent to. Some Financial Institutions optimize routing of files to allow processing during the same calendar day or to benefit from physical locality. This is done in part by the ABA routing number prefix. Paygate has long term plans to perform routing optimizations like this, but currently does no such optimization.
 
-### SFTP Uploads of Merged ACH Files
+### FTP Uploads of Merged ACH Files
 
-ACH files which are uploaded to another FI primarily use SFTP (Secure File Transport Protocol) and follow a filename pattern like: `YYYYMMDD-ABA-N.ach` (example: `20181222-301234567-1.ach`). The SFTP configuration is stored within a database that Paygate controls ~~and can be modified with admin HTTP endpoints~~. (Please [comment on this GitHub issue for HTTP configuration endpoints](https://github.com/moov-io/paygate/issues/147))
+ACH files which are uploaded to another FI primarily use FTP (Secure File Transport Protocol) and follow a filename pattern like: `YYYYMMDD-ABA-N.ach` (example: `20181222-301234567-1.ach`). The FTP configuration is stored within a database that Paygate controls ~~and can be modified with admin HTTP endpoints~~. (Please [comment on this GitHub issue for HTTP configuration endpoints](https://github.com/moov-io/paygate/issues/147))
 
 There's a Prometheus metric exposed for tracking ACH file uploads `ach_files_uploaded{destination="..", origin=".."}`.
 
 #### Configuration
 
-Paygate currently offers a read endpoint for the configuration related to SFTP file uploads. Call `GET /configs/uploads` against the admin server (`:9092` by default) to retrieve a JSON representation of the configuration. If HTTP endpoints to update/delete configuration would be helpful please [comment or star this GitHub issue](https://github.com/moov-io/paygate/issues/147).
+Paygate currently offers a read endpoint for the configuration related to FTP file uploads. Call `GET /configs/uploads` against the admin server (`:9092` by default) to retrieve a JSON representation of the configuration. If HTTP endpoints to update/delete configuration would be helpful please [comment or star this GitHub issue](https://github.com/moov-io/paygate/issues/147).
 
 Otherwise, the following SQLite and MySQL tables can be configured. Insert, update or delete rows from the following:
 
 - `cutoff_times`: Last time of each operating day for ACH file uploads to be processed.
    - Exmaple: cutoff: `1700` (5pm), location: `America/New_York` (IANA Time Zone database values)
 - `file_transfer_configs`: Path configuration for inbound, outbound, and return directories on the FTP server.
-- `sftp_configs`: FTP configuration for ACH file uploads (authentication and connection parameters).
+- `ftp_configs`: FTP configuration for ACH file uploads (authentication and connection parameters).
 
 Note, paygate exposes a Prometheus metric `missing_ach_file_upload_configs{routing_number="..."}` which counts how often configurations aren't found for given routing numbers. These need to be addressed by a human operator (insert the proper configurations) so files can be uploaded to a Financial Institution.
 
 ### Returned ACH Files
 
-Returned ACH files are downloaded via SFTP by paygate and processed. Each file is expected to have an [Addenda99](https://godoc.org/github.com/moov-io/ach#Addenda99) ACH record containing a return code. This return code is used sometimes to update the Depository status. Transfers are always marked as `reclaimed` upon their return being processed.
+Returned ACH files are downloaded via FTP by paygate and processed. Each file is expected to have an [Addenda99](https://godoc.org/github.com/moov-io/ach#Addenda99) ACH record containing a return code. This return code is used sometimes to update the Depository status. Transfers are always marked as `reclaimed` upon their return being processed.
 
 ### Incoming ACH Files
 

--- a/file_transfer.go
+++ b/file_transfer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/jlaffaye/ftp"
 )
 
-type sftpConfig struct {
+type ftpConfig struct {
 	RoutingNumber string
 
 	Hostname           string
@@ -70,16 +70,16 @@ func (agent *ftpFileTransferAgent) close() error {
 }
 
 // newFileTransferAgent returns an FTP implementation of a fileTransferAgent
-func newFileTransferAgent(sftpConf *sftpConfig, conf *fileTransferConfig) (fileTransferAgent, error) {
+func newFileTransferAgent(ftpConf *ftpConfig, conf *fileTransferConfig) (fileTransferAgent, error) {
 	timeout := ftp.DialWithTimeout(30 * time.Second)
 	epsv := ftp.DialWithDisabledEPSV(false)
 
-	conn, err := ftp.Dial(sftpConf.Hostname, timeout, epsv)
+	conn, err := ftp.Dial(ftpConf.Hostname, timeout, epsv)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := conn.Login(sftpConf.Username, sftpConf.Password); err != nil {
+	if err := conn.Login(ftpConf.Username, ftpConf.Password); err != nil {
 		return nil, err
 	}
 	return &ftpFileTransferAgent{

--- a/file_transfer_async.go
+++ b/file_transfer_async.go
@@ -59,7 +59,7 @@ var (
 
 	missingFileUploadConfigs = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 		Name: "missing_ach_file_upload_configs",
-		Help: "Counter of missing configurations for file upload - sftp or file transfer config(s)",
+		Help: "Counter of missing configurations for file upload - ftp or file transfer config(s)",
 	}, []string{"routing_number"})
 
 	filesUploaded = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
@@ -99,7 +99,7 @@ func (c cutoffTime) MarshalJSON() ([]byte, error) {
 }
 
 // fileTransferController is a controller which is responsible for periodic sync'ing of ACH files
-// with their remote SFTP destination. The ACH network operates on uploading and downloding files
+// with their remote FTP destination. The ACH network operates on uploading and downloding files
 // from hosts during the business day.
 type fileTransferController struct {
 	rootDir   string
@@ -108,7 +108,7 @@ type fileTransferController struct {
 	interval    time.Duration
 	cutoffTimes []*cutoffTime
 
-	sftpConfigs         []*sftpConfig
+	ftpConfigs          []*ftpConfig
 	fileTransferConfigs []*fileTransferConfig
 
 	ach            *achclient.ACH
@@ -118,7 +118,7 @@ type fileTransferController struct {
 }
 
 // newFileTransferController returns a fileTransferController which is responsible for uploading ACH files
-// to their SFTP host for processing.
+// to their FTP host for processing.
 //
 // To change the refresh duration set ACH_FILE_TRANSFER_INTERVAL with a Go time.Duration value. (i.e. 10m for 10 minutes)
 func newFileTransferController(logger log.Logger, dir string, repo fileTransferRepository, achClient *achclient.ACH, accountsClient AccountsClient, accountsCallsDisabled bool) (*fileTransferController, error) {
@@ -150,13 +150,13 @@ func newFileTransferController(logger log.Logger, dir string, repo fileTransferR
 	if err != nil {
 		return nil, fmt.Errorf("file-transfer-controller: error reading cutoffTimes: %v", err)
 	}
-	sftpConfigs, err := repo.getSFTPConfigs()
+	ftpConfigs, err := repo.getFTPConfigs()
 	if err != nil {
-		return nil, fmt.Errorf("file-transfer-controller: error reading sftpConfigs: %v", err)
+		return nil, fmt.Errorf("file-transfer-controller: error reading ftpConfigs: %v", err)
 	}
 	fileTransferConfigs, err := repo.getFileTransferConfigs()
 	if err != nil {
-		return nil, fmt.Errorf("file-transfer-controller: error reading sftpConfigs: %v", err)
+		return nil, fmt.Errorf("file-transfer-controller: error reading ftpConfigs: %v", err)
 	}
 	rootDir, err := filepath.Abs(dir)
 	if err != nil || strings.Contains(dir, "..") {
@@ -171,7 +171,7 @@ func newFileTransferController(logger log.Logger, dir string, repo fileTransferR
 		interval:            interval,
 		batchSize:           batchSize,
 		cutoffTimes:         cutoffTimes,
-		sftpConfigs:         sftpConfigs,
+		ftpConfigs:          ftpConfigs,
 		fileTransferConfigs: fileTransferConfigs,
 		ach:                 achClient,
 		logger:              logger,
@@ -182,24 +182,24 @@ func newFileTransferController(logger log.Logger, dir string, repo fileTransferR
 	return controller, nil
 }
 
-func (c *fileTransferController) getDetails(cutoff *cutoffTime) (*sftpConfig, *fileTransferConfig) {
-	var sftp *sftpConfig
-	for i := range c.sftpConfigs {
-		if cutoff.routingNumber == c.sftpConfigs[i].RoutingNumber {
-			sftp = c.sftpConfigs[i]
+func (c *fileTransferController) getDetails(cutoff *cutoffTime) (*ftpConfig, *fileTransferConfig) {
+	var ftp *ftpConfig
+	for i := range c.ftpConfigs {
+		if cutoff.routingNumber == c.ftpConfigs[i].RoutingNumber {
+			ftp = c.ftpConfigs[i]
 			break
 		}
 	}
 	for i := range c.fileTransferConfigs {
 		if cutoff.routingNumber == c.fileTransferConfigs[i].RoutingNumber {
-			return sftp, c.fileTransferConfigs[i]
+			return ftp, c.fileTransferConfigs[i]
 		}
 	}
 	return nil, nil
 }
 
 // startPeriodicFileOperations will block forever to periodically download incoming and returned ACH files while also merging
-// and uploading ACH files to their remote SFTP server.
+// and uploading ACH files to their remote FTP server.
 //
 // Uploads will be completed before their cutoff time which is set for a given ABA routing number.
 func (c *fileTransferController) startPeriodicFileOperations(ctx context.Context, depRepo depositoryRepository, transferRepo transferRepository) {
@@ -261,13 +261,13 @@ func (c *fileTransferController) downloadAndProcessIncomingFiles(depRepo deposit
 	defer os.RemoveAll(dir)
 
 	for i := range c.cutoffTimes {
-		sftpConf, fileTransferConf := c.getDetails(c.cutoffTimes[i])
-		if sftpConf == nil || fileTransferConf == nil {
-			c.logger.Log("downloadAndProcessIncomingFiles", fmt.Sprintf("missing sftp and/or file transfer config for %s", c.cutoffTimes[i].routingNumber))
+		ftpConf, fileTransferConf := c.getDetails(c.cutoffTimes[i])
+		if ftpConf == nil || fileTransferConf == nil {
+			c.logger.Log("downloadAndProcessIncomingFiles", fmt.Sprintf("missing ftp and/or file transfer config for %s", c.cutoffTimes[i].routingNumber))
 			missingFileUploadConfigs.With("routing_number", c.cutoffTimes[i].routingNumber).Add(1)
 			continue
 		}
-		if err := c.downloadAllFiles(dir, sftpConf, fileTransferConf); err != nil {
+		if err := c.downloadAllFiles(dir, ftpConf, fileTransferConf); err != nil {
 			c.logger.Log("downloadAndProcessIncomingFiles", fmt.Sprintf("error downloading files into %s", dir), "error", err)
 			continue
 		}
@@ -287,16 +287,16 @@ func (c *fileTransferController) downloadAndProcessIncomingFiles(depRepo deposit
 }
 
 // downloadAllFiles will setup directories for each routing number and initiate downloading and writing the files to sub-directories.
-func (c *fileTransferController) downloadAllFiles(dir string, sftpConf *sftpConfig, fileTransferConf *fileTransferConfig) error {
-	agent, err := newFileTransferAgent(sftpConf, fileTransferConf)
+func (c *fileTransferController) downloadAllFiles(dir string, ftpConf *ftpConfig, fileTransferConf *fileTransferConfig) error {
+	agent, err := newFileTransferAgent(ftpConf, fileTransferConf)
 	if err != nil {
-		return fmt.Errorf("downloadAllFiles: problem with %s file transfer agent init: %v", sftpConf.RoutingNumber, err)
+		return fmt.Errorf("downloadAllFiles: problem with %s file transfer agent init: %v", ftpConf.RoutingNumber, err)
 	}
 	defer agent.close()
 
 	// Setup file downloads
 	if err := c.saveRemoteFiles(agent, dir); err != nil {
-		c.logger.Log("downloadAllFiles", fmt.Sprintf("ERROR downloading files (ABA: %s)", sftpConf.RoutingNumber), "error", err)
+		c.logger.Log("downloadAllFiles", fmt.Sprintf("ERROR downloading files (ABA: %s)", ftpConf.RoutingNumber), "error", err)
 	}
 	return nil
 }
@@ -504,7 +504,7 @@ func (c *fileTransferController) saveRemoteFiles(agent fileTransferAgent, dir st
 		for i := range files {
 			c.logger.Log("saveRemoteFiles", fmt.Sprintf("ACH: copied down inbound file %s", files[i].filename))
 
-			// Delete inbound file from SFTP server
+			// Delete inbound file from FTP server
 			if err := agent.delete(filepath.Join(agent.inboundPath(), files[i].filename)); err != nil {
 				c.logger.Log("saveRemoteFiles", fmt.Sprintf("ACH: problem deleting inbound file %s", files[i].filename), "error", err)
 			}
@@ -527,7 +527,7 @@ func (c *fileTransferController) saveRemoteFiles(agent fileTransferAgent, dir st
 		for i := range files {
 			c.logger.Log("saveRemoteFiles", fmt.Sprintf("ACH: copied down return file %s", files[i].filename))
 
-			// Delete return file from SFTP server
+			// Delete return file from FTP server
 			if err := agent.delete(filepath.Join(agent.returnPath(), files[i].filename)); err != nil {
 				c.logger.Log("saveRemoteFiles", fmt.Sprintf("ACH: problem deleting return file %s", files[i].filename), "error", err)
 			}
@@ -742,20 +742,20 @@ func (c *fileTransferController) mergeGroupableTransfer(mergedDir string, xfer *
 	return nil
 }
 
-// maybeUploadFile will grab the needed configs and upload an given file to the SFTP server for cutoffTime's routingNumber
+// maybeUploadFile will grab the needed configs and upload an given file to the FTP server for cutoffTime's routingNumber
 func (c *fileTransferController) maybeUploadFile(fileToUpload *achFile, cutoffTime *cutoffTime) error {
-	// Grab configs for setting up SFTP uploader
-	sftpConf, fileTransferConf := c.getDetails(cutoffTime)
-	if sftpConf == nil {
-		return fmt.Errorf("missing sftp config for %s", cutoffTime.routingNumber)
+	// Grab configs for setting up FTP uploader
+	ftpConf, fileTransferConf := c.getDetails(cutoffTime)
+	if ftpConf == nil {
+		return fmt.Errorf("missing ftp config for %s", cutoffTime.routingNumber)
 	}
 	if fileTransferConf == nil {
 		return fmt.Errorf("missing file transfer config for %s", cutoffTime.routingNumber)
 	}
 
-	agent, err := newFileTransferAgent(sftpConf, fileTransferConf)
+	agent, err := newFileTransferAgent(ftpConf, fileTransferConf)
 	if err != nil {
-		return fmt.Errorf("problem creating fileTransferAgent for %s: %v", sftpConf.RoutingNumber, err)
+		return fmt.Errorf("problem creating fileTransferAgent for %s: %v", ftpConf.RoutingNumber, err)
 	}
 	defer agent.close()
 

--- a/file_transfer_async_test.go
+++ b/file_transfer_async_test.go
@@ -99,8 +99,8 @@ func TestFileTransferController__newFileTransferController(t *testing.T) {
 	if len(controller.cutoffTimes) != 1 {
 		t.Errorf("local len(controller.cutoffTimes)=%d", len(controller.cutoffTimes))
 	}
-	if len(controller.sftpConfigs) != 1 {
-		t.Errorf("local len(controller.sftpConfigs)=%d", len(controller.sftpConfigs))
+	if len(controller.ftpConfigs) != 1 {
+		t.Errorf("local len(controller.ftpConfigs)=%d", len(controller.ftpConfigs))
 	}
 	if len(controller.fileTransferConfigs) != 1 {
 		t.Errorf("local len(controller.fileTransferConfigs)=%d", len(controller.fileTransferConfigs))
@@ -114,14 +114,14 @@ func TestFileTransferController__getDetails(t *testing.T) {
 		loc:           time.UTC,
 	}
 	controller := &fileTransferController{
-		sftpConfigs: []*sftpConfig{
+		ftpConfigs: []*ftpConfig{
 			{
 				RoutingNumber: "123",
-				Hostname:      "sftp.foo.com",
+				Hostname:      "ftp.foo.com",
 			},
 			{
 				RoutingNumber: "321",
-				Hostname:      "sftp.bar.com",
+				Hostname:      "ftp.bar.com",
 			},
 		},
 		fileTransferConfigs: []*fileTransferConfig{
@@ -137,21 +137,21 @@ func TestFileTransferController__getDetails(t *testing.T) {
 	}
 
 	// happy path - found
-	sftpConf, fileTransferConf := controller.getDetails(cutoff)
-	if sftpConf == nil || fileTransferConf == nil {
-		t.Fatalf("sftpConf=%v fileTransferConf=%v", sftpConf, fileTransferConf)
+	ftpConf, fileTransferConf := controller.getDetails(cutoff)
+	if ftpConf == nil || fileTransferConf == nil {
+		t.Fatalf("ftpConf=%v fileTransferConf=%v", ftpConf, fileTransferConf)
 	}
-	if sftpConf.Hostname != "sftp.foo.com" {
-		t.Errorf("sftpConf=%#v", sftpConf)
+	if ftpConf.Hostname != "ftp.foo.com" {
+		t.Errorf("ftpConf=%#v", ftpConf)
 	}
 	if fileTransferConf.InboundPath != "inbound/" {
 		t.Errorf("fileTransferConf=%#v", fileTransferConf)
 	}
 
 	// not found
-	sftpConf, fileTransferConf = controller.getDetails(&cutoffTime{routingNumber: "456"})
-	if sftpConf != nil || fileTransferConf != nil {
-		t.Fatalf("sftpConf=%v fileTransferConf=%v", sftpConf, fileTransferConf)
+	ftpConf, fileTransferConf = controller.getDetails(&cutoffTime{routingNumber: "456"})
+	if ftpConf != nil || fileTransferConf != nil {
+		t.Fatalf("ftpConf=%v fileTransferConf=%v", ftpConf, fileTransferConf)
 	}
 }
 

--- a/file_transfer_configs_test.go
+++ b/file_transfer_configs_test.go
@@ -40,15 +40,15 @@ func TestSqliteFileTransferRepository__getCounts(t *testing.T) {
 	defer repo.close()
 
 	writeCutoffTime(t, repo)
-	writeSFTPConfig(t, repo)
+	writeFTPConfig(t, repo)
 	writeFileTransferConfig(t, repo.db)
 
-	cutoffs, sftps, filexfers := repo.getCounts()
+	cutoffs, ftps, filexfers := repo.getCounts()
 	if cutoffs != 1 {
 		t.Errorf("got %d", cutoffs)
 	}
-	if sftps != 1 {
-		t.Errorf("got %d", sftps)
+	if ftps != 1 {
+		t.Errorf("got %d", ftps)
 	}
 	if filexfers != 1 {
 		t.Errorf("got %d", filexfers)
@@ -100,10 +100,10 @@ func TestSqliteFileTransferRepository__getCutoffTimes(t *testing.T) {
 	}
 }
 
-func writeSFTPConfig(t *testing.T, repo *testSqliteFileTransferRepository) {
+func writeFTPConfig(t *testing.T, repo *testSqliteFileTransferRepository) {
 	t.Helper()
 
-	query := `insert into sftp_configs (routing_number, hostname, username, password) values ('123456789', 'ftp.moov.io', 'moov', 'secret');`
+	query := `insert into ftp_configs (routing_number, hostname, username, password) values ('123456789', 'ftp.moov.io', 'moov', 'secret');`
 	stmt, err := repo.db.Prepare(query)
 	if err != nil {
 		t.Fatal(err)
@@ -114,14 +114,14 @@ func writeSFTPConfig(t *testing.T, repo *testSqliteFileTransferRepository) {
 	}
 }
 
-func TestSqliteFileTransferRepository__getSFTPConfigs(t *testing.T) {
+func TestSqliteFileTransferRepository__getFTPConfigs(t *testing.T) {
 	repo := createTestSqliteFileTransferRepository(t)
 	defer repo.close()
 
-	writeSFTPConfig(t, repo)
+	writeFTPConfig(t, repo)
 
 	// now read
-	configs, err := repo.getSFTPConfigs()
+	configs, err := repo.getFTPConfigs()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,9 +230,9 @@ func TestFileTransferConfigs__maskPassword(t *testing.T) {
 		t.Errorf("got %q", v)
 	}
 
-	out := maskPasswords([]*sftpConfig{{Password: "password"}})
+	out := maskPasswords([]*ftpConfig{{Password: "password"}})
 	if len(out) != 1 {
-		t.Errorf("got %d sftpConfigs: %v", len(out), out)
+		t.Errorf("got %d ftpConfigs: %v", len(out), out)
 	}
 	if out[0].Password != "p******d" {
 		t.Errorf("got %q", out[0].Password)
@@ -267,8 +267,8 @@ func TestFileTransferConfigsHTTP__getFileTransferConfigs(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		t.Fatal(err)
 	}
-	if len(response.CutoffTimes) == 0 || len(response.SFTPConfigs) == 0 || len(response.FileTransferConfigs) == 0 {
-		t.Errorf("response.CutoffTimes=%d response.SFTPConfigs=%d response.FileTransferConfigs=%d", len(response.CutoffTimes), len(response.SFTPConfigs), len(response.FileTransferConfigs))
+	if len(response.CutoffTimes) == 0 || len(response.FTPConfigs) == 0 || len(response.FileTransferConfigs) == 0 {
+		t.Errorf("response.CutoffTimes=%d response.FTPConfigs=%d response.FileTransferConfigs=%d", len(response.CutoffTimes), len(response.FTPConfigs), len(response.FileTransferConfigs))
 	}
 }
 
@@ -278,5 +278,5 @@ func TestFileTransferConfigsHTTP__getFileTransferConfigs(t *testing.T) {
 // svc.AddHandler("/configs/uploads/file-transfers/{routingNumber}", upsertFileTransferConfig(logger, repo))
 // svc.AddHandler("/configs/uploads/file-transfers/{routingNumber}", deleteFileTransferConfig(logger, repo))
 
-// svc.AddHandler("/configs/uploads/sftp/{routingNumber}", upsertSFTPConfig(logger, repo))
-// svc.AddHandler("/configs/uploads/sftp/{routingNumber}", deleteSFTPConfig(logger, repo))
+// svc.AddHandler("/configs/uploads/ftp/{routingNumber}", upsertFTPConfig(logger, repo))
+// svc.AddHandler("/configs/uploads/ftp/{routingNumber}", deleteFTPConfig(logger, repo))

--- a/file_transfer_test.go
+++ b/file_transfer_test.go
@@ -78,7 +78,7 @@ func port() int {
 	return int(30000 + (portSource.Int63() % 9999))
 }
 
-func createTestSFTPServer(t *testing.T) (*server.Server, error) {
+func createTestFTPServer(t *testing.T) (*server.Server, error) {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("skipping due to -short")
@@ -121,8 +121,8 @@ func createTestFTPConnection(t *testing.T, svc *server.Server) (*ftp.ServerConn,
 	return conn, nil
 }
 
-func TestSFTP(t *testing.T) {
-	svc, err := createTestSFTPServer(t)
+func TestFTP(t *testing.T) {
+	svc, err := createTestFTPServer(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestSFTP(t *testing.T) {
 }
 
 func createTestFileTransferAgent(t *testing.T) (*server.Server, fileTransferAgent) {
-	svc, err := createTestSFTPServer(t)
+	svc, err := createTestFTPServer(t)
 	if err != nil {
 		return nil, nil
 	}
@@ -169,7 +169,7 @@ func createTestFileTransferAgent(t *testing.T) (*server.Server, fileTransferAgen
 	if !ok {
 		t.Errorf("unknown svc.Auth: %T", svc.Auth)
 	}
-	sftpConf := &sftpConfig{
+	ftpConf := &ftpConfig{
 		Hostname: fmt.Sprintf("%s:%d", svc.Hostname, svc.Port),
 		Username: auth.Name,
 		Password: auth.Password,
@@ -179,7 +179,7 @@ func createTestFileTransferAgent(t *testing.T) (*server.Server, fileTransferAgen
 		OutboundPath: "outbound",
 		ReturnPath:   "returned",
 	}
-	agent, err := newFileTransferAgent(sftpConf, conf)
+	agent, err := newFileTransferAgent(ftpConf, conf)
 	if err != nil {
 		svc.Shutdown()
 		t.Fatalf("problem creating FileTransferAgent: %v", err)
@@ -188,7 +188,7 @@ func createTestFileTransferAgent(t *testing.T) (*server.Server, fileTransferAgen
 	return svc, agent
 }
 
-func TestSFTP__getInboundFiles(t *testing.T) {
+func TestFTP__getInboundFiles(t *testing.T) {
 	svc, agent := createTestFileTransferAgent(t)
 	defer agent.close()
 	defer svc.Shutdown()
@@ -222,7 +222,7 @@ func TestSFTP__getInboundFiles(t *testing.T) {
 	}
 }
 
-func TestSFTP__getReturnFiles(t *testing.T) {
+func TestFTP__getReturnFiles(t *testing.T) {
 	svc, agent := createTestFileTransferAgent(t)
 	defer agent.close()
 	defer svc.Shutdown()
@@ -256,7 +256,7 @@ func TestSFTP__getReturnFiles(t *testing.T) {
 	}
 }
 
-func TestSFTP__uploadFile(t *testing.T) {
+func TestFTP__uploadFile(t *testing.T) {
 	svc, agent := createTestFileTransferAgent(t)
 	defer agent.close()
 	defer svc.Shutdown()

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -96,8 +96,10 @@ func mysqlConnection(logger log.Logger, user, pass string, address string, datab
 			// File Merging and Uploading
 			`create table if not exists cutoff_times(routing_number varchar(10), cutoff varchar(10), location varchar(25));`,
 			`create table if not exists file_transfer_configs(routing_number varchar(10), inbound_path varchar(100), outbound_path varchar(100), return_path varchar(100));`,
-			// // TODO(adam): sftp_configs needs the password encrypted? (or stored in vault)
-			`create table if not exists sftp_configs(routing_number varchar(10), hostname varchar(100), username varchar(25), password varchar(25));`,
+
+			// TODO(adam): We need to rename sftp_configs to ftp_configs (and create a new sftp_configs table for ssh-based file transfer)
+			// TODO(adam): ftp_configs needs the password encrypted? (or stored in vault)
+			`create table if not exists ftp_configs(routing_number varchar(10), hostname varchar(100), username varchar(25), password varchar(25));`,
 		},
 	}
 }

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -112,8 +112,10 @@ func sqliteConnection(logger log.Logger, path string) *sqlite {
 			// File Merging and Uploading
 			`create table if not exists cutoff_times(routing_number, cutoff, location);`,
 			`create table if not exists file_transfer_configs(routing_number, inbound_path, outbound_path, return_path);`,
-			// TODO(adam): sftp_configs needs the password encrypted? (or stored in vault)
-			`create table if not exists sftp_configs(routing_number, hostname, username, password);`,
+
+			// TODO(adam): We need to rename sftp_configs to ftp_configs (and create a new sftp_configs table for ssh-based file transfer)
+			// TODO(adam): ftp_configs needs the password encrypted? (or stored in vault)
+			`create table if not exists ftp_configs(routing_number, hostname, username, password);`,
 		},
 		connections: sqliteConnections,
 	}


### PR DESCRIPTION
SFTP is a different protocol (that we also need to support), so let's
call the existing implementation what it is -- FTP.

Issue: #173