### PR TITLE
files: support setting additional root certificates for FTP connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The following environmental variables can be set to configure behavior in paygat
 #### ACH file uploading / transfers
 
 - `ACH_FILE_BATCH_SIZE`: Number of Transfers to retrieve from the database in each batch for mergin before upload to Fed.
+- `ACH_FILE_TRANSFERS_CAFILE`: Filepath for additional (CA) certificates to be added into each FTP client used within paygate
 - `ACH_FILE_TRANSFER_INTERVAL`: Go duration for how often to check and sync ACH files on their FTP destinations.
    - Note: Set the value `off` to completely disable async file downloads and uploads.
 - `ACH_FILE_STORAGE_DIR`: Filepath for temporary storage of ACH files. This is used as a scratch directory to manage outbound and incoming/returned ACH files.

--- a/file_transfer_test.go
+++ b/file_transfer_test.go
@@ -159,6 +159,26 @@ func TestFTP(t *testing.T) {
 	}
 }
 
+func TestFTP__tlsDialOption(t *testing.T) {
+	if testing.Short() {
+		return // skip network calls
+	}
+
+	cafile, err := grabConnectionCertificates(t, "google.com:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cafile)
+
+	opt, err := tlsDialOption(cafile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opt == nil {
+		t.Fatal("nil tls DialOption")
+	}
+}
+
 func createTestFileTransferAgent(t *testing.T) (*server.Server, fileTransferAgent) {
 	svc, err := createTestFTPServer(t)
 	if err != nil {


### PR DESCRIPTION


This allows private root CA's to be used with FTP connections.

Issue: #176