### PR TITLE
files: set fileTransferController.rootDiir in all tests

### DIFF
--- a/file_transfer_async_test.go
+++ b/file_transfer_async_test.go
@@ -233,7 +233,8 @@ func TestFileTransferController__saveRemoteFiles(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	controller := &fileTransferController{
-		logger: log.NewNopLogger(),
+		rootDir: dir, // use our temp dir
+		logger:  log.NewNopLogger(),
 	}
 	if err := controller.saveRemoteFiles(agent, dir); err != nil {
 		t.Error(err)


### PR DESCRIPTION
This was missed in one test which caused us to use paygate's root dir (rather than a temp dir) for clutterting of test files/dirs.