### PR TITLE
main: if ACH_FILE_STORAGE_DIR is our zero value use ./storage/

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func main() {
 
 	// Start periodic ACH file sync
 	achStorageDir := filepath.Dir(os.Getenv("ACH_FILE_STORAGE_DIR"))
-	if achStorageDir == "" {
+	if achStorageDir == "." {
 		achStorageDir = "./storage/"
 	}
 	if err := os.MkdirAll(achStorageDir, 0777); err != nil {


### PR DESCRIPTION
filepath.Dir returns '.' on an empty string (to represent the current dir) so our check needs to be aware of that