### PR TITLE
internal/filetransfer: add DEV_FILE_TRANSFER_TYPE for local dev

### DIFF
--- a/file_transfer_async_test.go
+++ b/file_transfer_async_test.go
@@ -50,7 +50,7 @@ func TestFileTransferController__newFileTransferController(t *testing.T) {
 	if len(controller.cutoffTimes) != 1 {
 		t.Errorf("local len(controller.cutoffTimes)=%d", len(controller.cutoffTimes))
 	}
-	if len(controller.sftpConfigs) != 1 {
+	if len(controller.sftpConfigs) != 0 {
 		t.Errorf("local len(controller.sftpConfigs)=%d", len(controller.sftpConfigs))
 	}
 	if len(controller.fileTransferConfigs) != 1 {

--- a/internal/filetransfer/config_test.go
+++ b/internal/filetransfer/config_test.go
@@ -251,7 +251,7 @@ func TestFileTransferConfigsHTTP__GetConfigs(t *testing.T) {
 	go svc.Listen()
 	defer svc.Shutdown()
 
-	repo := &localFileTransferRepository{}
+	repo := newLocalFileTransferRepository("ftp")
 
 	AddFileTransferConfigRoutes(log.NewNopLogger(), svc, repo)
 
@@ -277,8 +277,42 @@ func TestFileTransferConfigsHTTP__GetConfigs(t *testing.T) {
 	if len(response.CutoffTimes) == 0 || len(response.FileTransferConfigs) == 0 {
 		t.Errorf("response.CutoffTimes=%d response.FileTransferConfigs=%d", len(response.CutoffTimes), len(response.FileTransferConfigs))
 	}
-	if len(response.FTPConfigs) == 0 || len(response.SFTPConfigs) == 0 {
+	if len(response.FTPConfigs) == 0 || len(response.SFTPConfigs) != 0 {
 		t.Errorf("response.FTPConfigs=%d response.SFTPConfigs=%d", len(response.FTPConfigs), len(response.SFTPConfigs))
+	}
+}
+
+func TestLocalFileTransferRepository(t *testing.T) {
+	repo := newLocalFileTransferRepository("ftp")
+	ftpConfigs, err := repo.GetFTPConfigs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ftpConfigs) != 1 {
+		t.Errorf("FTP Configs: %#v", ftpConfigs)
+	}
+	sftpConfigs, err := repo.GetSFTPConfigs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sftpConfigs) != 0 {
+		t.Errorf("SFTP Configs: %#v", sftpConfigs)
+	}
+
+	repo = newLocalFileTransferRepository("sftp")
+	ftpConfigs, err = repo.GetFTPConfigs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ftpConfigs) != 0 {
+		t.Errorf("FTP Configs: %#v", ftpConfigs)
+	}
+	sftpConfigs, err = repo.GetSFTPConfigs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sftpConfigs) != 1 {
+		t.Errorf("SFTP Configs: %#v", sftpConfigs)
 	}
 }
 


### PR DESCRIPTION
This config value allows paygate to switch between its local dev FTP and SFTP servers for quick testing of the async file retrieval and uploading.

While this is dev/testing code in production any deployment should override these with their own configuration for each FI.