### PR TITLE
internal/filetransfer: sftp: create remote outbound dir and upload into it

### DIFF
--- a/internal/filetransfer/ftp.go
+++ b/internal/filetransfer/ftp.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -171,7 +172,8 @@ func (agent *FTPTransferAgent) UploadFile(f File) error {
 	}(wd)
 
 	// Write file contents into path
-	return agent.conn.Stor(f.Filename, f.Contents)
+	// Take the base of f.Filename and our (out of band) OutboundPath to avoid accepting a write like '../../../../etc/passwd'.
+	return agent.conn.Stor(filepath.Base(f.Filename), f.Contents)
 }
 
 func (agent *FTPTransferAgent) GetInboundFiles() ([]File, error) {

--- a/internal/filetransfer/sftp.go
+++ b/internal/filetransfer/sftp.go
@@ -268,8 +268,8 @@ func (agent *SFTPTransferAgent) UploadFile(f File) error {
 		}
 	}
 
-	// TODO(adam): technically doesn't this need to be path-joined according to the remote OS?
-	fd, err := agent.client.Create(filepath.Join(agent.cfg.OutboundPath, f.Filename))
+	// Take the base of f.Filename and our (out of band) OutboundPath to avoid accepting a write like '../../../../etc/passwd'.
+	fd, err := agent.client.Create(filepath.Join(agent.cfg.OutboundPath, filepath.Base(f.Filename)))
 	if err != nil {
 		return fmt.Errorf("sftp: problem creating %s: %v", f.Filename, err)
 	}

--- a/internal/filetransfer/sftp_test.go
+++ b/internal/filetransfer/sftp_test.go
@@ -201,7 +201,7 @@ func TestSFTP__password(t *testing.T) {
 	}
 
 	err := deployment.agent.UploadFile(File{
-		Filename: deployment.agent.OutboundPath() + "upload.ach",
+		Filename: "upload.ach",
 		Contents: ioutil.NopCloser(strings.NewReader("test data")),
 	})
 	if err != nil {

--- a/internal/filetransfer/sftp_test.go
+++ b/internal/filetransfer/sftp_test.go
@@ -260,6 +260,35 @@ func TestSFTP__ClientPrivateKey(t *testing.T) { // TODO(adam): need to write thi
 
 }
 
+func TestSFTP__uploadFile(t *testing.T) {
+	deployment := spawnSFTP(t)
+	defer deployment.close(t)
+
+	if err := deployment.agent.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	// force out OutboundPath to create more directories
+	deployment.agent.cfg.OutboundPath = filepath.Join("upload", "foo")
+	err := deployment.agent.UploadFile(File{
+		Filename: "upload.ach",
+		Contents: ioutil.NopCloser(strings.NewReader("test data")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// fail to create the OutboundPath
+	deployment.agent.cfg.OutboundPath = string(os.PathSeparator) + filepath.Join("home", "bad-path")
+	err = deployment.agent.UploadFile(File{
+		Filename: "upload.ach",
+		Contents: ioutil.NopCloser(strings.NewReader("test data")),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestSFTP__readPubKey(t *testing.T) {
 	// TODO(adam): test with '-----BEGIN RSA PRIVATE KEY-----' PKCS#8 format
 


### PR DESCRIPTION

This fixes two bugs:

1. If the remote outbound directory doesn't exist, attempt to create it.
2. Upload files into the outbound directory, not the current dir.

Issue: https://github.com/moov-io/paygate/issues/170 