### PR TITLE
files: read ACH_FILE_MAX_LINES to override NACHA 10k line default

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The following environmental variables can be set to configure behavior in paygat
 | Environmental Variable | Description | Default |
 |-----|-----|-----|
 | `ACH_FILE_BATCH_SIZE` | Number of Transfers to retrieve from the database in each batch for mergin before upload to Fed. | 100 |
+| `ACH_FILE_MAX_LINES` | Maximum line count before an ACH file is uploaded to its remote server. NACHA guidelines have a hard limit of 10,000 lines. | 10000 |
 | `ACH_FILE_TRANSFERS_CAFILE` | Filepath for additional (CA) certificates to be added into each FTP client used within paygate. | Empty |
 | `ACH_FILE_TRANSFER_INTERVAL` | Go duration for how often to check and sync ACH files on their SFTP destinations. (Set to `off` to disable.) | `10m` |
 | `ACH_FILE_STORAGE_DIR` | Filepath for temporary storage of ACH files. This is used as a scratch directory to manage outbound and incoming/returned ACH files. | `./storage/` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       ACH_ENDPOINT: 'http://ach:8080'
       FED_ENDPOINT: 'http://fed:8086'
       OFAC_ENDPOINT: 'http://ofac:8084'
+      ACH_FILE_MAX_LINES: 20 # upload files when they're a lot smaller than the 10k default
     depends_on:
       - ach
       - accounts


### PR DESCRIPTION
This allows local dev installs to upload smaller files and if any FI has specific requirements. 

Issue: https://github.com/moov-io/paygate/issues/200 