### PR TITLE
build: in local dev merge and upload way more often

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       FED_ENDPOINT: 'http://fed:8086'
       OFAC_ENDPOINT: 'http://ofac:8084'
       ACH_FILE_MAX_LINES: 20 # upload files when they're a lot smaller than the 10k default
+      ACH_FILE_TRANSFER_INTERVAL: 30s # Merge and Upload files this often
     depends_on:
       - ach
       - accounts


### PR DESCRIPTION
A few users have reported not seeing files in storage/merged/ which is
likely due to the default (10 minute) interval. Let's lower that in
local dev.

Issue: https://github.com/moov-io/paygate/issues/200