### PR TITLE
files: upload ACH files to their origin, not destination

### DIFF
--- a/file_transfer_async.go
+++ b/file_transfer_async.go
@@ -711,7 +711,7 @@ func (c *fileTransferController) mergeGroupableTransfer(mergedDir string, xfer *
 		return nil
 	}
 	// Find (or create) a mergable file for this transfer's destination
-	mergableFile, err := grabLatestMergedACHFile(xfer.destination, file, mergedDir)
+	mergableFile, err := grabLatestMergedACHFile(xfer.origin, file, mergedDir)
 	if err != nil {
 		c.logger.Log("mergeGroupableTransfer", fmt.Sprintf("unable to find mergable file for transfer %s", xfer.ID), "error", err)
 		return nil
@@ -888,8 +888,8 @@ func (f *achFile) write() error {
 //
 // grabLatestMergedACHFile will rollover files if they're at or beyond the 10k line limit
 // This function will ignore files that don't end with '*.ach'
-func grabLatestMergedACHFile(destinationRoutingNumber string, incoming *ach.File, dir string) (*achFile, error) {
-	matches, err := filepath.Glob(filepath.Join(dir, fmt.Sprintf("*-%s-*.ach", destinationRoutingNumber)))
+func grabLatestMergedACHFile(originRoutingNumber string, incoming *ach.File, dir string) (*achFile, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, fmt.Sprintf("*-%s-*.ach", originRoutingNumber)))
 	if err != nil {
 		return nil, err
 	}
@@ -903,7 +903,7 @@ func grabLatestMergedACHFile(destinationRoutingNumber string, incoming *ach.File
 
 		mergableFile := &achFile{
 			File:     incoming,
-			filepath: filepath.Join(dir, achFilename(destinationRoutingNumber, 1)),
+			filepath: filepath.Join(dir, achFilename(originRoutingNumber, 1)),
 		}
 
 		// We need to increment the FileIDModifier in the FileHeader when creating a new file.
@@ -940,7 +940,7 @@ func groupTransfers(xfers []*groupableTransfer, err error) ([][]*groupableTransf
 	for i := range xfers {
 		inserted := false
 		for j := range out {
-			if xfers[i].destination == out[j][0].destination {
+			if xfers[i].origin == out[j][0].origin {
 				inserted = true
 				out[j] = append(out[j], xfers[i])
 			}

--- a/file_transfer_async_test.go
+++ b/file_transfer_async_test.go
@@ -357,7 +357,7 @@ func TestFileTransferController__mergeGroupableTransfer(t *testing.T) {
 		Transfer: &Transfer{
 			ID: TransferID(base.ID()),
 		},
-		destination: "076401251", // from testdata/ppd-debit.ach
+		origin: "076401251", // from testdata/ppd-debit.ach
 	}
 
 	db := database.CreateTestSqliteDB(t)
@@ -376,7 +376,7 @@ func TestFileTransferController__mergeGroupableTransfer(t *testing.T) {
 	}
 
 	// check our mergable files
-	mergableFile, err := grabLatestMergedACHFile(xfer.destination, file, dir)
+	mergableFile, err := grabLatestMergedACHFile(xfer.origin, file, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -491,19 +491,19 @@ func TestFileTransferController__groupTransfers(t *testing.T) {
 			Transfer: &Transfer{
 				ID: "1",
 			},
-			destination: "123456789",
+			origin: "123456789",
 		},
 		{
 			Transfer: &Transfer{
 				ID: "2",
 			},
-			destination: "123456789",
+			origin: "123456789",
 		},
 		{
 			Transfer: &Transfer{
 				ID: "3",
 			},
-			destination: "987654321",
+			origin: "987654321",
 		},
 	}
 	grouped, err := groupTransfers(transfers, nil)

--- a/transfers.go
+++ b/transfers.go
@@ -851,9 +851,9 @@ type transferCursor struct {
 type groupableTransfer struct {
 	*Transfer
 
-	// destination is the ABA routing number of the destination FI
-	// This comes from the Transfers.ReceiverDepository.Destination
-	destination string
+	// origin is the ABA routing number of the Originating FI (ODFI)
+	// This comes from the Transfer's OriginatorDepository.RoutingNumber
+	origin string
 
 	userId string
 }
@@ -898,14 +898,14 @@ func (cur *transferCursor) Next() ([]*groupableTransfer, error) {
 		if err != nil {
 			continue
 		}
-		receiverDep, err := cur.depRepo.getUserDepository(t.ReceiverDepository, xfers[i].userId)
-		if err != nil || receiverDep == nil {
+		originDep, err := cur.depRepo.getUserDepository(t.OriginatorDepository, xfers[i].userId)
+		if err != nil || originDep == nil {
 			continue
 		}
 		transfers = append(transfers, &groupableTransfer{
-			Transfer:    t,
-			destination: receiverDep.RoutingNumber,
-			userId:      xfers[i].userId,
+			Transfer: t,
+			origin:   originDep.RoutingNumber,
+			userId:   xfers[i].userId,
 		})
 		if xfers[i].createdAt.After(max) {
 			max = xfers[i].createdAt // advance max to newest time

--- a/transfers_test.go
+++ b/transfers_test.go
@@ -926,9 +926,9 @@ func TestTransfers_transferCursor(t *testing.T) {
 			Type:                   PushTransfer,
 			Amount:                 amt("12.12"),
 			Originator:             OriginatorID("originator1"),
-			OriginatorDepository:   DepositoryID("originator1"),
+			OriginatorDepository:   dep.ID, // OriginatorDepository is read from a depositoryRepository
 			Receiver:               ReceiverID("receiver1"),
-			ReceiverDepository:     dep.ID, // ReceiverDepository is read from a depositoryRepository
+			ReceiverDepository:     DepositoryID("receiver1"),
 			Description:            "money1",
 			StandardEntryClassCode: "PPD",
 			fileId:                 "test-file1",
@@ -942,9 +942,9 @@ func TestTransfers_transferCursor(t *testing.T) {
 			Type:                   PullTransfer,
 			Amount:                 amt("13.13"),
 			Originator:             OriginatorID("originator2"),
-			OriginatorDepository:   DepositoryID("originator2"),
+			OriginatorDepository:   dep.ID,
 			Receiver:               ReceiverID("receiver2"),
-			ReceiverDepository:     dep.ID,
+			ReceiverDepository:     DepositoryID("receiver2"),
 			Description:            "money2",
 			StandardEntryClassCode: "PPD",
 			fileId:                 "test-file2",
@@ -958,9 +958,9 @@ func TestTransfers_transferCursor(t *testing.T) {
 			Type:                   PushTransfer,
 			Amount:                 amt("14.14"),
 			Originator:             OriginatorID("originator3"),
-			OriginatorDepository:   DepositoryID("originator3"),
+			OriginatorDepository:   dep.ID,
 			Receiver:               ReceiverID("receiver3"),
-			ReceiverDepository:     dep.ID,
+			ReceiverDepository:     DepositoryID("receiver3"),
 			Description:            "money3",
 			StandardEntryClassCode: "PPD",
 			fileId:                 "test-file3",
@@ -1031,9 +1031,9 @@ func TestTransfers_markTransferAsMerged(t *testing.T) {
 			Type:                   PushTransfer,
 			Amount:                 amt("12.12"),
 			Originator:             OriginatorID("originator1"),
-			OriginatorDepository:   DepositoryID("originator1"),
+			OriginatorDepository:   dep.ID, // ReceiverDepository is read from a depositoryRepository
 			Receiver:               ReceiverID("receiver1"),
-			ReceiverDepository:     dep.ID, // ReceiverDepository is read from a depositoryRepository
+			ReceiverDepository:     DepositoryID("receiver1"),
 			Description:            "money1",
 			StandardEntryClassCode: "PPD",
 			fileId:                 "test-file1",
@@ -1053,6 +1053,7 @@ func TestTransfers_markTransferAsMerged(t *testing.T) {
 		for i := range firstBatch {
 			t.Errorf("firstBatch[%d]=%#v", i, firstBatch[i])
 		}
+		t.Fatalf("firstBatch: %#v", firstBatch)
 	}
 
 	// mark our transfer as merged, so we don't see it (in a new transferCursor we create)
@@ -1067,9 +1068,9 @@ func TestTransfers_markTransferAsMerged(t *testing.T) {
 			Type:                   PullTransfer,
 			Amount:                 amt("13.13"),
 			Originator:             OriginatorID("originator2"),
-			OriginatorDepository:   DepositoryID("originator2"),
+			OriginatorDepository:   dep.ID,
 			Receiver:               ReceiverID("receiver2"),
-			ReceiverDepository:     dep.ID,
+			ReceiverDepository:     DepositoryID("receiver2"),
 			Description:            "money2",
 			StandardEntryClassCode: "PPD",
 			fileId:                 "test-file2",


### PR DESCRIPTION
ACH files are uploaded to their ODFI which passes them to the FED which passes them to the RDFI.

Fixes: https://github.com/moov-io/paygate/issues/204