### PR TITLE
internal/filetransfer: ignore nil os.FileInfo's from readdir calls

### DIFF
--- a/internal/filetransfer/ftp.go
+++ b/internal/filetransfer/ftp.go
@@ -210,6 +210,9 @@ func (agent *FTPTransferAgent) readFiles(path string) ([]File, error) {
 	}
 	var files []File
 	for i := range items {
+		if items[i] == "" {
+			continue
+		}
 		resp, err := agent.conn.Retr(items[i])
 		if err != nil {
 			return nil, fmt.Errorf("problem retrieving %s: %v", items[i], err)

--- a/internal/filetransfer/sftp.go
+++ b/internal/filetransfer/sftp.go
@@ -302,6 +302,9 @@ func (agent *SFTPTransferAgent) readFiles(dir string) ([]File, error) {
 
 	var files []File
 	for i := range infos {
+		if infos[i] == nil {
+			continue
+		}
 		fd, err := agent.client.Open(filepath.Join(dir, infos[i].Name()))
 		if err != nil {
 			return nil, fmt.Errorf("sftp: open %s: %v", infos[i].Name(), err)


### PR DESCRIPTION
Not quite sure what the filesystem layout was, but a user reported this nil panic.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x9f50c8]

goroutine 1062 [running]:
github.com/moov-io/paygate/internal/filetransfer.(*SFTPTransferAgent).readFiles(0xc00006d580, 0xc0002b9940, 0x13, 0x0, 0xc000336068, 0x7, 0xc00031f080, 0xc0005b9b18)
    /go/src/github.com/moov-io/paygate/internal/filetransfer/sftp.go:307 +0x148
```