### PR TITLE
files: setup a channel for manually merge and upload of Transfers

### DIFF
--- a/file_transfer_async.go
+++ b/file_transfer_async.go
@@ -195,10 +195,11 @@ func (c *fileTransferController) findTransferType(routingNumber string) string {
 }
 
 // startPeriodicFileOperations will block forever to periodically download incoming and returned ACH files while also merging
-// and uploading ACH files to their remote SFTP server.
+// and uploading ACH files to their remote SFTP server. forceUpload is a channel for manually triggering the "merge and upload"
+// portion of this pooling loop, which is used by admin endpoints and to make testing easier.
 //
 // Uploads will be completed before their cutoff time which is set for a given ABA routing number.
-func (c *fileTransferController) startPeriodicFileOperations(ctx context.Context, depRepo depositoryRepository, transferRepo transferRepository) {
+func (c *fileTransferController) startPeriodicFileOperations(ctx context.Context, forceUpload chan struct{}, depRepo depositoryRepository, transferRepo transferRepository) {
 	tick := time.NewTicker(c.interval)
 	defer tick.Stop()
 
@@ -206,13 +207,18 @@ func (c *fileTransferController) startPeriodicFileOperations(ctx context.Context
 	transferCursor := transferRepo.getTransferCursor(c.batchSize, depRepo)
 
 	for {
-		select {
-		case <-tick.C:
-			c.logger.Log("startPeriodicFileOperations", "Starting periodic file operations")
-			var wg sync.WaitGroup
-			errs := make(chan error, 10)
+		// Setup our concurrnet waiting
+		var wg sync.WaitGroup
+		errs := make(chan error, 10)
 
-			// For all routing numbers grab their inbound and return files
+		select {
+		case <-forceUpload:
+			c.logger.Log("startPeriodicFileOperations", "forcing merge and upload of ACH files")
+			goto uploadFiles
+
+		case <-tick.C:
+			// This is triggered by the time.Ticker (which accounts for delays) so let's download and upload files.
+			c.logger.Log("startPeriodicFileOperations", "Starting periodic file operations")
 			wg.Add(1)
 			go func() {
 				if err := c.downloadAndProcessIncomingFiles(depRepo, transferRepo); err != nil {
@@ -220,28 +226,30 @@ func (c *fileTransferController) startPeriodicFileOperations(ctx context.Context
 				}
 				wg.Done()
 			}()
-
-			// Grab transfers, merge them into files, and upload any which are complete.
-			wg.Add(1)
-			go func() {
-				if err := c.mergeAndUploadFiles(transferCursor, transferRepo); err != nil {
-					errs <- fmt.Errorf("mergeAndUploadFiles: %v", err)
-				}
-				wg.Done()
-			}()
-
-			// Wait for all operations to complete
-			wg.Wait()
-			errs <- nil // send so channel read doesn't block
-			if err := <-errs; err != nil {
-				c.logger.Log("startPeriodicFileOperations", fmt.Sprintf("ERROR: periodic file operation"), "error", err)
-			} else {
-				c.logger.Log("startPeriodicFileOperations", fmt.Sprintf("files sync'd, waiting %v", c.interval))
-			}
+			goto uploadFiles
 
 		case <-ctx.Done():
 			c.logger.Log("startPeriodicFileOperations", "Shutting down due to context.Done()")
 			return
+		}
+
+	uploadFiles:
+		// Grab transfers, merge them into files, and upload any which are complete.
+		wg.Add(1)
+		go func() {
+			if err := c.mergeAndUploadFiles(transferCursor, transferRepo); err != nil {
+				errs <- fmt.Errorf("mergeAndUploadFiles: %v", err)
+			}
+			wg.Done()
+		}()
+
+		// Wait for all operations to complete
+		wg.Wait()
+		errs <- nil // send so channel read doesn't block
+		if err := <-errs; err != nil {
+			c.logger.Log("startPeriodicFileOperations", fmt.Sprintf("ERROR: periodic file operation"), "error", err)
+		} else {
+			c.logger.Log("startPeriodicFileOperations", fmt.Sprintf("files sync'd, waiting %v", c.interval))
 		}
 	}
 }

--- a/file_transfer_sync.go
+++ b/file_transfer_sync.go
@@ -1,0 +1,32 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/moov-io/base/admin"
+	moovhttp "github.com/moov-io/base/http"
+
+	"github.com/go-kit/kit/log"
+)
+
+func addFileTransferSyncRoute(logger log.Logger, svc *admin.Server, forceUpload chan struct{}) {
+	svc.AddHandler("/files/upload", forceFileUpload(logger, forceUpload))
+}
+
+func forceFileUpload(logger log.Logger, forceUpload chan struct{}) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			moovhttp.Problem(w, fmt.Errorf("unsupported HTTP verb %s", r.Method))
+			return
+		}
+
+		forceUpload <- struct{}{} // send a messge for the receiving end
+
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/file_transfer_sync_test.go
+++ b/file_transfer_sync_test.go
@@ -1,0 +1,56 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/moov-io/base/admin"
+
+	"github.com/go-kit/kit/log"
+)
+
+func TestForceFileUpload(t *testing.T) {
+	svc := admin.NewServer(":0")
+	go svc.Listen()
+	defer svc.Shutdown()
+
+	forceFileUplaods := make(chan struct{}, 1) // buffered channel
+	addFileTransferSyncRoute(log.NewNopLogger(), svc, forceFileUplaods)
+
+	req, err := http.NewRequest("POST", "http://localhost"+svc.BindAddr()+"/files/upload", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("bogus HTTP status: %d", resp.StatusCode)
+	}
+
+	// we need to read from this channel to ensure a message was sent
+	// if there's no message the test will timeout
+	<-forceFileUplaods
+
+	// use the wrong HTTP verb and get an error
+	req, err = http.NewRequest("GET", "http://localhost"+svc.BindAddr()+"/files/upload", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("bogus HTTP status: %d", resp.StatusCode)
+	}
+}

--- a/transfers_test.go
+++ b/transfers_test.go
@@ -77,6 +77,8 @@ type mockTransferRepository struct {
 	xfer   *Transfer
 	fileId string
 
+	cur *transferCursor
+
 	err error
 
 	// Updated fields
@@ -126,7 +128,7 @@ func (r *mockTransferRepository) setReturnCode(id TransferID, returnCode string)
 }
 
 func (r *mockTransferRepository) getTransferCursor(batchSize int, depRepo depositoryRepository) *transferCursor {
-	return nil // TODO?
+	return r.cur
 }
 
 func (r *mockTransferRepository) markTransferAsMerged(id TransferID, filename string, traceNumber string) error {


### PR DESCRIPTION
This setup allows us to trigger the process for converting paygate Transfer objects into ACH files which are uploaded to their ODFI. Initially this is exposed over an admin HTTP endpoint.

Issue: https://github.com/moov-io/paygate/issues/200