### PR TITLE
micro-deposits: add admin route for reading micro-deposits

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,6 +174,9 @@ func main() {
 		filetransfer.AddFileTransferConfigRoutes(logger, adminServer, fileTransferRepo)
 	}
 
+	// Register the micro-deposit admin route
+	addMicroDepositAdminRoutes(logger, adminServer, depositoryRepo)
+
 	// Create HTTP handler
 	handler := mux.NewRouter()
 	addReceiverRoutes(logger, handler, ofacClient, receiverRepo, depositoryRepo)


### PR DESCRIPTION
This will be used by customer service to view the deposits made and
can be leveraged in testing to quickly read micro-deposit values.

Issue: https://github.com/moov-io/paygate/issues/213 