### PR TITLE
files: drop cpu usage (infinite loop) in transfer merging for upload

### DIFF
--- a/file_transfer_async.go
+++ b/file_transfer_async.go
@@ -639,90 +639,95 @@ func (c *fileTransferController) mergeAndUploadFiles(transferCur *transferCursor
 	os.Mkdir(mergedDir, 0777) // ensure dir is created
 	c.logger.Log("file-transfer-controller", "Starting file merge and upload operations")
 
-	errCount := 0
-	for {
-		var filesToUpload []*achFile // accumulator
+	var filesToUpload []*achFile // accumulator
 
-		// Read the next batch of Transfers to merge and upload. Currently no marking is done on these rows to indicate they've been picked up
-		// so any attempt to run multiple paygate instances will result in duplicating Transfers on the remote FI server. We do store merged_filename
-		// on Transfers, but that's only after they have been merged into a file (not in the stage of "read from DB, merging into file."
-		//
-		// Should we mark Transfers? We need to have a code branch that sweeps all transfers to ensure we aren't missing any.
-		//
-		// See: https://github.com/moov-io/paygate/issues/178
-		groupedTransfers, err := groupTransfers(transferCur.Next())
-		if err != nil {
-			if errCount > 3 {
-				return fmt.Errorf("mergeAndUploadFiles: to many groupedTransfer errors (retries=%d): %v", errCount, err)
+	// Read the next batch of Transfers to merge and upload. Currently no marking is done on these rows to indicate they've been picked up
+	// so any attempt to run multiple paygate instances will result in duplicating Transfers on the remote FI server. We do store merged_filename
+	// on Transfers, but that's only after they have been merged into a file (not in the stage of "read from DB, merging into file."
+	//
+	// Should we mark Transfers? We need to have a code branch that sweeps all transfers to ensure we aren't missing any.
+	//
+	// See: https://github.com/moov-io/paygate/issues/178
+	groupedTransfers, err := groupTransfers(transferCur.Next())
+	if err != nil {
+		return fmt.Errorf("problem grouping transfers: %v", err)
+	}
+	// Group transfers by ABA and add to mergable files
+	for i := range groupedTransfers {
+		for j := range groupedTransfers[i] {
+			if fileToUpload := c.mergeGroupableTransfer(mergedDir, groupedTransfers[i][j], transferRepo); fileToUpload != nil {
+				filesToUpload = append(filesToUpload, fileToUpload)
 			}
-			errCount++
-			continue
 		}
-		// Group transfers by ABA and add to mergable files
-		for i := range groupedTransfers {
-			for j := range groupedTransfers[i] {
-				if fileToUpload := c.mergeGroupableTransfer(mergedDir, groupedTransfers[i][j], transferRepo); fileToUpload != nil {
-					filesToUpload = append(filesToUpload, fileToUpload)
+	}
+
+	// TODO(adam): What would it take to read these as Transfer objects and re-use this method's logic? This is a lot to duplicate.
+	// We need to read an ACH file back into its Transfer (see: groupableTransfer), which is doable since submitMicroDeposits creates an ACH file.
+	microDeposits, err := microDepositCur.Next()
+	if err != nil {
+		return fmt.Errorf("problem getting micro-deposits: %v", err)
+	}
+	// Group micro-deposits by ABA and add to mergable files
+	for i := range microDeposits {
+		if file := c.mergeMicroDeposit(mergedDir, microDeposits[i], microDepositCur.depRepo); file != nil {
+			filesToUpload = append(filesToUpload, file)
+		}
+	}
+
+	// Find files close to their cutoff to enqueue
+	toUpload, err := filesNearTheirCutoff(c.cutoffTimes, mergedDir)
+	if err != nil {
+		return fmt.Errorf("problem with filesNearTheirCutoff: %v", err)
+	}
+	if len(toUpload) > 0 {
+		filesToUpload = append(filesToUpload, toUpload...)
+	}
+
+	// Upload files
+	for i := range filesToUpload {
+		for j := range c.cutoffTimes {
+			if filesToUpload[i].Header.ImmediateDestination == c.cutoffTimes[j].RoutingNumber {
+				if err := c.maybeUploadFile(filesToUpload[i], c.cutoffTimes[j]); err != nil {
+					return fmt.Errorf("problem uploading %s: %v", filesToUpload[i].filepath, err)
 				}
-			}
-		}
-
-		// TODO(adam): What would it take to read these as Transfer objects and re-use this method's logic? This is a lot to duplicate.
-		// We need to read an ACH file back into its Transfer (see: groupableTransfer), which is doable since submitMicroDeposits creates an ACH file.
-		microDeposits, err := microDepositCur.Next()
-		if err != nil {
-			if errCount > 3 {
-				return fmt.Errorf("mergeAndUploadFiles: to many micro-deposit errors (retries=%d): %v", errCount, err)
-			}
-			errCount++
-			continue
-		}
-		// Group micro-deposits by ABA and add to mergable files
-		for i := range microDeposits {
-			if file := c.mergeMicroDeposit(mergedDir, microDeposits[i], microDepositCur.depRepo); file != nil {
-				filesToUpload = append(filesToUpload, file)
-			}
-		}
-
-		// Find files close to their cutoff to enqueue
-		for i := range c.cutoffTimes {
-			matches, err := filepath.Glob(fmt.Sprintf("*-%s-*.ach", c.cutoffTimes[i].RoutingNumber))
-			if err != nil || len(matches) == 0 {
-				continue
-			}
-			// If we're close to the cutoffTime then enqueue for upload
-			diff := c.cutoffTimes[i].Diff(time.Now())
-			if diff > 0*time.Second && diff <= forcedCutoffUploadDelta {
-				for j := range matches {
-					file, err := parseACHFilepath(filepath.Join(mergedDir, matches[j]))
-					if err != nil {
-						continue
-					}
-					filesToUpload = append(filesToUpload, &achFile{
-						File:     file,
-						filepath: filepath.Join(mergedDir, matches[j]),
-					})
-				}
-			}
-		}
-
-		// Upload files
-		for i := range filesToUpload {
-			for j := range c.cutoffTimes {
-				if filesToUpload[i].Header.ImmediateDestination == c.cutoffTimes[j].RoutingNumber {
-					if err := c.maybeUploadFile(filesToUpload[i], c.cutoffTimes[j]); err != nil {
-						c.logger.Log("mergeAndUploadFiles", fmt.Sprintf("problem uploading %s", filesToUpload[i].filepath), "error", err.Error())
-						continue // skip, don't rename if we failed the upload
-					}
-					// rename the file so grabLatestMergedACHFile ignores it next time
-					if err := os.Rename(filesToUpload[i].filepath, filesToUpload[i].filepath+".uploaded"); err != nil {
-						c.logger.Log("mergeAndUploadFiles", fmt.Sprintf("error renaming %s after upload", filesToUpload[i].filepath), "error", err.Error())
-					}
+				// rename the file so grabLatestMergedACHFile ignores it next time
+				if err := os.Rename(filesToUpload[i].filepath, filesToUpload[i].filepath+".uploaded"); err != nil {
+					return fmt.Errorf("error renaming %s after upload: %v", filesToUpload[i].filepath, err)
 				}
 			}
 		}
 	}
 	return nil
+}
+
+func filesNearTheirCutoff(cutoffTimes []*filetransfer.CutoffTime, dir string) ([]*achFile, error) {
+	var filesToUpload []*achFile
+
+	for i := range cutoffTimes {
+		pattern := filepath.Join(dir, fmt.Sprintf("*-%s-*.ach", cutoffTimes[i].RoutingNumber))
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("dir=%s: %v", dir, err)
+		}
+
+		// If we're close to the cutoffTime then enqueue for upload
+		diff := cutoffTimes[i].Diff(time.Now().In(cutoffTimes[i].Loc))
+
+		if diff > 0*time.Second && diff <= forcedCutoffUploadDelta {
+			for j := range matches {
+				file, err := parseACHFilepath(matches[j])
+				if err != nil {
+					return nil, fmt.Errorf("matches[%d]=%s: %v", j, matches[j], err)
+				}
+				filesToUpload = append(filesToUpload, &achFile{
+					File:     file,
+					filepath: matches[j],
+				})
+			}
+		}
+	}
+
+	return filesToUpload, nil
 }
 
 // mergeGroupableTransfer will inspect a Transfer, load the backing ACH file and attempt to merge that transfer into an existing merge file for upload.

--- a/file_transfer_async_test.go
+++ b/file_transfer_async_test.go
@@ -319,6 +319,66 @@ func TestFileTransferController__saveRemoteFiles(t *testing.T) {
 		t.Errorf("deleted file was %s", agent.deletedFile)
 	}
 }
+func TestFileTransferController__filesNearTheirCutoff(t *testing.T) {
+	nyc, _ := time.LoadLocation("America/New_York")
+	now := time.Now().In(nyc)
+
+	dir, err := ioutil.TempDir("", "filesNearTheirCutoff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// use a valid file
+	src, err := os.Open(filepath.Join("testdata", "ppd-debit.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	dst, err := os.Create(filepath.Join(dir, achFilename("987654320", 1)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup our cutoff time to be "just head" in time
+	cutoffTimes := []*filetransfer.CutoffTime{
+		{
+			RoutingNumber: "987654320",
+			Cutoff:        (now.Hour() * 100) + now.Minute() + 1, // 1 minute in the future in HHmm
+			Loc:           nyc,
+		},
+	}
+
+	outFiles, err := filesNearTheirCutoff(cutoffTimes, dir)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(outFiles) != 1 {
+		t.Fatalf("got %d files, expected one file for upload", len(outFiles))
+	}
+	if outFiles[0] == nil || outFiles[0].File == nil {
+		t.Fatalf("outFiles[0]=%#v", outFiles[0])
+	}
+
+	// verify the file exists (for the sad path test)
+	fds, _ := ioutil.ReadDir(dir)
+	if len(fds) != 1 {
+		t.Errorf("got %d files", len(fds))
+	}
+
+	// bump out time ahead
+	cutoffTimes[0].Cutoff += 100 // add one hour
+	outFiles, err = filesNearTheirCutoff(cutoffTimes, dir)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(outFiles) != 0 {
+		t.Fatal("expected no files (as cutoff is far enough forward in time)")
+	}
+}
 
 func TestFileTransferController__mergeTransfer(t *testing.T) {
 	// build a mergableFile from an example WEB entry

--- a/internal/filetransfer/file_transfer.go
+++ b/internal/filetransfer/file_transfer.go
@@ -80,7 +80,7 @@ type CutoffTime struct {
 // diff returns the time.Duration between when and the CutoffTime
 // A negative value will be returned if the cutoff has already passed
 func (c *CutoffTime) Diff(when time.Time) time.Duration {
-	now := time.Now()
+	now := time.Now().In(c.Loc)
 	ct := time.Date(now.Year(), now.Month(), now.Day(), c.Cutoff/100, c.Cutoff%100, 0, 0, c.Loc)
 	return ct.Sub(when)
 }


### PR DESCRIPTION
This was reported by Ray as he noticed high CPU usage when paygate was
idle shortly after startup. A quick profile shows this looping was the
main cause as it didn't properly exit out in error conditions.

For now we're going to remove the errCount condition and just error
whenever a problem is encountered. If lower levels need retries then
we can add those on the lower level.