### PR TITLE
internal/filetransfer: fix timezone issues in CutoffTime tests

### DIFF
--- a/internal/filetransfer/file_transfer.go
+++ b/internal/filetransfer/file_transfer.go
@@ -81,8 +81,8 @@ type CutoffTime struct {
 // A negative value will be returned if the cutoff has already passed
 func (c *CutoffTime) Diff(when time.Time) time.Duration {
 	now := time.Now().In(c.Loc)
-	ct := time.Date(now.Year(), now.Month(), now.Day(), c.Cutoff/100, c.Cutoff%100, 0, 0, c.Loc)
-	return ct.Sub(when)
+	ct := time.Date(now.Year(), now.Month(), now.Day(), c.Cutoff/100, c.Cutoff%100, 0, 0, c.Loc).In(c.Loc)
+	return ct.Sub(when.In(c.Loc))
 }
 
 func (c CutoffTime) MarshalJSON() ([]byte, error) {

--- a/internal/filetransfer/file_transfer_test.go
+++ b/internal/filetransfer/file_transfer_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestCutoffTime(t *testing.T) {
-	now := time.Now()
 	loc, _ := time.LoadLocation("America/New_York")
+	now := time.Now().In(loc)
 	ct := &CutoffTime{RoutingNumber: "123456789", Cutoff: 1700, Loc: loc}
 
 	// before


### PR DESCRIPTION
Ran into during https://github.com/moov-io/paygate/pull/209 