### PR TITLE
micro-deposits: grow mysql file_id column to store '*-micro-deposit-verify' IDs

### DIFF
--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -81,6 +81,10 @@ var (
 			"add_merged_filename_to_micro_deposits",
 			"alter table micro_deposits add column merged_filename varchar(100);",
 		),
+		execsql(
+			"grow_micro_deposits_file_id",
+			"alter table micro_deposits modify file_id varchar(100)",
+		),
 	)
 )
 

--- a/microDeposits_test.go
+++ b/microDeposits_test.go
@@ -240,6 +240,40 @@ func TestMicroDeposits__repository(t *testing.T) {
 	check(t, &sqliteDepositoryRepo{mysqlDB.DB, log.NewNopLogger()})
 }
 
+func TestMicroDeposits__insertMicroDepositVerify(t *testing.T) {
+	t.Parallel()
+
+	check := func(t *testing.T, repo depositoryRepository) {
+		id, userID := DepositoryID(base.ID()), base.ID()
+
+		amt, _ := NewAmount("USD", "0.11")
+		mc := microDeposit{amount: *amt, fileID: base.ID() + "-micro-deposit-verify"}
+		mcs := []microDeposit{mc}
+
+		if err := repo.initiateMicroDeposits(id, userID, mcs); err != nil {
+			t.Fatal(err)
+		}
+
+		microDeposits, err := repo.getMicroDeposits(id, userID)
+		if n := len(microDeposits); err != nil || n == 0 {
+			t.Fatalf("n=%d error=%v", n, err)
+		}
+		if m := microDeposits[0]; m.fileID != mc.fileID {
+			t.Errorf("got %s", m.fileID)
+		}
+	}
+
+	// SQLite tests
+	sqliteDB := database.CreateTestSqliteDB(t)
+	defer sqliteDB.Close()
+	check(t, &sqliteDepositoryRepo{sqliteDB.DB, log.NewNopLogger()})
+
+	// MySQL tests
+	mysqlDB := database.CreateTestMySQLDB(t)
+	defer mysqlDB.Close()
+	check(t, &sqliteDepositoryRepo{mysqlDB.DB, log.NewNopLogger()})
+}
+
 func TestMicroDeposits__initiateError(t *testing.T) {
 	id, userID := DepositoryID(base.ID()), base.ID()
 	depRepo := &mockDepositoryRepository{err: errors.New("bad error")}


### PR DESCRIPTION


The fileID limit before was too small to properly store our larger
strings, so let's grow the column size.

Fixes: https://github.com/moov-io/paygate/issues/230