### PR TITLE
micro-deposits: debit the micro-deposit from the remote account when crediting

### DIFF
--- a/microDeposits_test.go
+++ b/microDeposits_test.go
@@ -564,6 +564,13 @@ func TestMicroDeposits__addMicroDepositReversal(t *testing.T) {
 	file := ach.NewFile()
 	file.AddBatch(batch)
 
+	// nil, so expect no changes
+	addMicroDepositReversal(nil)
+	if len(file.Batches) != 1 || len(file.Batches[0].GetEntries()) != 1 {
+		t.Fatalf("file.Batches[0]=%#v", file.Batches[0])
+	}
+
+	// add reversal batch
 	addMicroDepositReversal(file)
 
 	// verify

--- a/microDeposits_test.go
+++ b/microDeposits_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	accounts "github.com/moov-io/accounts/client"
+	"github.com/moov-io/ach"
 	"github.com/moov-io/base"
 	"github.com/moov-io/base/admin"
 	"github.com/moov-io/paygate/internal/database"
@@ -545,4 +546,41 @@ func readMergedFilename(repo *SQLDepositoryRepo, amount *Amount, id DepositoryID
 		return "", err
 	}
 	return mergedFilename, nil
+}
+
+func TestMicroDeposits__addMicroDepositReversal(t *testing.T) {
+	ed := ach.NewEntryDetail()
+	ed.TransactionCode = ach.CheckingCredit
+	ed.TraceNumber = "123"
+
+	bh := ach.NewBatchHeader()
+	bh.StandardEntryClassCode = "PPD"
+	batch, err := ach.NewBatch(bh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch.AddEntry(ed)
+
+	file := ach.NewFile()
+	file.AddBatch(batch)
+
+	addMicroDepositReversal(file)
+
+	// verify
+	if len(file.Batches) != 1 {
+		t.Fatalf("file.Batches=%#v", file.Batches)
+	}
+	entries := file.Batches[0].GetEntries()
+	if len(entries) != 2 {
+		t.Fatalf("entries=%#v", entries)
+	}
+	if entries[0].TransactionCode-5 != entries[1].TransactionCode {
+		t.Errorf("entries[0].TransactionCode=%d entries[1].TransactionCode=%d", entries[0].TransactionCode, entries[1].TransactionCode)
+	}
+	if entries[0].Amount != entries[1].Amount {
+		t.Errorf("entries[0].Amount=%d entries[1].Amount=%d", entries[0].Amount, entries[1].Amount)
+	}
+	if entries[1].TraceNumber != "124" {
+		t.Errorf("entries[1].TraceNumber=%s", entries[1].TraceNumber)
+	}
 }

--- a/transfers_ccd_test.go
+++ b/transfers_ccd_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCCD__createCCDBatch(t *testing.T) {
-	id, userId := base.ID(), base.ID()
+	id, userID := base.ID(), base.ID()
 	receiverDep := &Depository{
 		ID:            DepositoryID(base.ID()),
 		BankName:      "foo bank",
@@ -64,11 +64,26 @@ func TestCCD__createCCDBatch(t *testing.T) {
 		},
 	}
 
-	batch, err := createCCDBatch(id, userId, transfer, receiver, receiverDep, orig, origDep)
+	batch, err := createCCDBatch(id, userID, transfer, receiver, receiverDep, orig, origDep)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if batch == nil {
 		t.Error("nil CCD Batch")
+	}
+
+	file, err := constructACHFile(id, "", userID, transfer, receiver, receiverDep, orig, origDep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file == nil {
+		t.Error("nil CCD ach.File")
+	}
+
+	// sad path, empty CCDDetail.PaymentInformation
+	transfer.CCDDetail.PaymentInformation = ""
+	batch, err = createCCDBatch(id, userID, transfer, receiver, receiverDep, orig, origDep)
+	if err == nil || batch != nil {
+		t.Fatalf("expected error: batch=%#v", batch)
 	}
 }

--- a/transfers_iat_test.go
+++ b/transfers_iat_test.go
@@ -57,7 +57,7 @@ func TestIAT__validate(t *testing.T) {
 }
 
 func TestIAT__createIATBatch(t *testing.T) {
-	id, userId := base.ID(), base.ID()
+	id, userID := base.ID(), base.ID()
 	receiverDep := &Depository{
 		ID:            DepositoryID(base.ID()),
 		BankName:      "foo bank",
@@ -133,11 +133,19 @@ func TestIAT__createIATBatch(t *testing.T) {
 		},
 	}
 
-	batch, err := createIATBatch(id, userId, transfer, receiver, receiverDep, orig, origDep)
+	batch, err := createIATBatch(id, userID, transfer, receiver, receiverDep, orig, origDep)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if batch == nil {
 		t.Error("nil IAT Batch")
+	}
+
+	file, err := constructACHFile(id, "", userID, transfer, receiver, receiverDep, orig, origDep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file == nil {
+		t.Error("nil IAT ach.File")
 	}
 }

--- a/transfers_tel_test.go
+++ b/transfers_tel_test.go
@@ -5,11 +5,28 @@
 package paygate
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/moov-io/base"
 )
+
+func TestTELPaymentType(t *testing.T) {
+	var paymentType TELPaymentType
+	if err := json.Unmarshal([]byte(`"SINGLE"`), &paymentType); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(`"ReoCCuRRing"`), &paymentType); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(`"other"`), &paymentType); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := json.Unmarshal([]byte("1"), &paymentType); err == nil {
+		t.Fatal("expected error")
+	}
+}
 
 func TestTEL__createTELBatch(t *testing.T) {
 	id, userID := base.ID(), base.ID()
@@ -71,6 +88,14 @@ func TestTEL__createTELBatch(t *testing.T) {
 	}
 	if batch == nil {
 		t.Error("nil TEL Batch")
+	}
+
+	file, err := constructACHFile(id, "", userID, transfer, receiver, receiverDep, orig, origDep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file == nil {
+		t.Error("nil TEL ach.File")
 	}
 
 	// Make sure TELReoccurring are rejected

--- a/transfers_test.go
+++ b/transfers_test.go
@@ -1457,7 +1457,7 @@ func TestTransfers__setReturnCode(t *testing.T) {
 	check(t, mysqlDB.DB)
 }
 
-func TestTransfers__createACHFile(t *testing.T) {
+func TestTransfers__constructACHFile(t *testing.T) {
 	// The fields on each struct are minimized to help throttle this file's size
 	receiverDep := &Depository{
 		BankName:      "foo bank",
@@ -1475,9 +1475,9 @@ func TestTransfers__createACHFile(t *testing.T) {
 		StandardEntryClassCode: "AAA", // invalid
 	}
 
-	fileID, err := createACHFile(nil, "", "", "", transfer, receiver, receiverDep, orig, origDep)
-	if err == nil || fileID != "" {
-		t.Fatalf("expected error, got fileID=%q", fileID)
+	file, err := constructACHFile("", "", "", transfer, receiver, receiverDep, orig, origDep)
+	if err == nil || file != nil {
+		t.Fatalf("expected error, got file=%#v", file)
 	}
 	if !strings.Contains(err.Error(), "unsupported SEC code: AAA") {
 		t.Errorf("unexpected error: %v", err)

--- a/transfers_test.go
+++ b/transfers_test.go
@@ -451,6 +451,105 @@ func TestTransfers__read(t *testing.T) {
 	check(t, requests[0])
 }
 
+func TestTransfers__create(t *testing.T) {
+	db := database.CreateTestSqliteDB(t)
+	defer db.Close()
+
+	logger := log.NewNopLogger()
+	now := base.NewTime(time.Now())
+
+	depRepo := &mockDepositoryRepository{
+		depositories: []*Depository{
+			{
+				ID:            DepositoryID("originator"),
+				BankName:      "orig bank",
+				Holder:        "orig",
+				HolderType:    Individual,
+				Type:          Checking,
+				RoutingNumber: "121421212",
+				AccountNumber: "1321",
+				Status:        DepositoryVerified,
+				Metadata:      "metadata",
+				Created:       now,
+				Updated:       now,
+			},
+			{
+				ID:            DepositoryID("receiver"),
+				BankName:      "receiver bank",
+				Holder:        "receiver",
+				HolderType:    Individual,
+				Type:          Checking,
+				RoutingNumber: "121421212",
+				AccountNumber: "323431",
+				Status:        DepositoryVerified,
+				Metadata:      "metadata",
+				Created:       now,
+				Updated:       now,
+			},
+		},
+	}
+	eventRepo := NewEventRepo(logger, db.DB)
+	recRepo := &mockReceiverRepository{
+		receivers: []*Receiver{
+			{
+				ID:                ReceiverID("receiver"),
+				Email:             "foo@moov.io",
+				DefaultDepository: DepositoryID("receiver"),
+				Status:            ReceiverVerified,
+				Metadata:          "other",
+				Created:           now,
+				Updated:           now,
+			},
+		},
+	}
+	origRepo := &mockOriginatorRepository{
+		originators: []*Originator{
+			{
+				ID:                OriginatorID("originator"),
+				DefaultDepository: DepositoryID("originator"),
+				Identification:    "id",
+				Metadata:          "other",
+				Created:           now,
+				Updated:           now,
+			},
+		},
+	}
+	repo := &SQLTransferRepo{db.DB, log.NewNopLogger()}
+
+	amt, _ := NewAmount("USD", "18.61")
+	request := &transferRequest{
+		Type:                   PushTransfer,
+		Amount:                 *amt,
+		Originator:             OriginatorID("originator"),
+		OriginatorDepository:   DepositoryID("originator"),
+		Receiver:               ReceiverID("receiver"),
+		ReceiverDepository:     DepositoryID("receiver"),
+		Description:            "money",
+		StandardEntryClassCode: "PPD",
+		fileID:                 "test-file",
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(request); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+
+	router := createTestTransferRouter(depRepo, eventRepo, recRepo, origRepo, repo, func(r *mux.Router) { achclient.AddCreateRoute(w, r) })
+	defer router.close()
+	router.accountsCallsDisabled = true // don't make Accounts calls
+
+	req, _ := http.NewRequest("POST", "/transfers", &body)
+	req.Header.Set("x-user-id", "test")
+	router.createUserTransfers()(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bogus HTTP statu codes: %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestTransfers__idempotency(t *testing.T) {
 	// The repositories aren't used, aka idempotency check needs to be first.
 	xferRouter := createTestTransferRouter(nil, nil, nil, nil, nil)

--- a/transfers_web_test.go
+++ b/transfers_web_test.go
@@ -23,10 +23,13 @@ func TestWEBPaymentType(t *testing.T) {
 	if err := json.Unmarshal([]byte(`"other"`), &paymentType); err == nil {
 		t.Fatal(err)
 	}
+	if err := json.Unmarshal([]byte("1"), &paymentType); err == nil {
+		t.Fatal("expected error")
+	}
 }
 
 func TestWEB__createWEBBatch(t *testing.T) {
-	id, userId := base.ID(), base.ID()
+	id, userID := base.ID(), base.ID()
 	receiverDep := &Depository{
 		ID:            DepositoryID(base.ID()),
 		BankName:      "foo bank",
@@ -80,7 +83,7 @@ func TestWEB__createWEBBatch(t *testing.T) {
 		},
 	}
 
-	batch, err := createWEBBatch(id, userId, transfer, receiver, receiverDep, orig, origDep)
+	batch, err := createWEBBatch(id, userID, transfer, receiver, receiverDep, orig, origDep)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,9 +91,17 @@ func TestWEB__createWEBBatch(t *testing.T) {
 		t.Error("nil WEB Batch")
 	}
 
+	file, err := constructACHFile(id, "", userID, transfer, receiver, receiverDep, orig, origDep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file == nil {
+		t.Error("nil WEB ach.File")
+	}
+
 	// Make sure WEBReoccurring are rejected
 	transfer.WEBDetail.PaymentType = "reoccurring"
-	batch, err = createWEBBatch(id, userId, transfer, receiver, receiverDep, orig, origDep)
+	batch, err = createWEBBatch(id, userID, transfer, receiver, receiverDep, orig, origDep)
 	if batch != nil || err == nil {
 		t.Errorf("expected error, but got batch: %v", batch)
 	} else {


### PR DESCRIPTION
When we send money to a remote account as a micro-deposit this money needs to come back to us (paygate's account). To do this we include a debit (to counteract the credit) from the remote account back to paygate's.

Issue: https://github.com/moov-io/paygate/issues/238