### PR TITLE
optimize micro-deposits in a Batch and withdraw deposits

### DIFF
--- a/common.go
+++ b/common.go
@@ -162,7 +162,7 @@ func (a *Amount) FromString(str string) error {
 		}
 		number = (whole * 100) + dec
 	}
-	if number <= 0 {
+	if number < 0 {
 		return fmt.Errorf("unable to read %s", parts[1])
 	}
 

--- a/common.go
+++ b/common.go
@@ -16,6 +16,11 @@ import (
 	"golang.org/x/text/currency"
 )
 
+var (
+	// ErrDifferentCurrencies is returned when an operation on an Amount instance is attempted with another Amount of a different currency (symbol).
+	ErrDifferentCurrencies = errors.New("different currencies")
+)
+
 type AccountType string
 
 const (
@@ -73,6 +78,15 @@ func (a *Amount) Validate() error {
 
 func (a Amount) Equal(other Amount) bool {
 	return a.String() == other.String()
+}
+
+// Plus returns an Amount of adding both Amount instances together.
+// Currency symbols must match for Plus to return without errors.
+func (a Amount) Plus(other Amount) (Amount, error) {
+	if a.symbol != other.symbol {
+		return a, ErrDifferentCurrencies
+	}
+	return Amount{number: a.number + other.number, symbol: a.symbol}, nil
 }
 
 // NewAmountFromInt returns an Amount object after converting an integer amount (in cents)

--- a/common_test.go
+++ b/common_test.go
@@ -263,3 +263,16 @@ func TestStartOfDayAndTomorrow(t *testing.T) {
 		t.Errorf("max - min = %v", v)
 	}
 }
+
+func TestAmount__plus(t *testing.T) {
+	amt1, _ := NewAmount("USD", "0.11")
+	amt2, _ := NewAmount("USD", "0.13")
+
+	if a, err := amt1.Plus(*amt2); err != nil {
+		t.Fatal(err)
+	} else {
+		if v := a.String(); v != "USD 0.24" {
+			t.Fatalf("got %v", v)
+		}
+	}
+}

--- a/common_test.go
+++ b/common_test.go
@@ -276,3 +276,12 @@ func TestAmount__plus(t *testing.T) {
 		}
 	}
 }
+
+func TestAmount__zero(t *testing.T) {
+	if amt, err := NewAmount("USD", "0.00"); err != nil {
+		t.Fatalf("amt=%v error=%v", amt, err)
+	}
+	if amt, err := NewAmountFromInt("USD", 0); err != nil {
+		t.Fatalf("amt=%v error=%v", amt, err)
+	}
+}

--- a/common_test.go
+++ b/common_test.go
@@ -275,6 +275,16 @@ func TestAmount__plus(t *testing.T) {
 			t.Fatalf("got %v", v)
 		}
 	}
+
+	// invalid case
+	amt1.symbol = "GBP"
+	if _, err := amt1.Plus(*amt2); err == nil {
+		t.Error("expected error")
+	} else {
+		if err != ErrDifferentCurrencies {
+			t.Errorf("got %T %#v", err, err)
+		}
+	}
 }
 
 func TestAmount__zero(t *testing.T) {

--- a/events_test.go
+++ b/events_test.go
@@ -15,6 +15,43 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
+type testEventRepository struct {
+	err error
+
+	event *Event
+}
+
+func (r *testEventRepository) getEvent(eventID EventID, userID string) (*Event, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.event, nil
+}
+
+func (r *testEventRepository) getUserEvents(userID string) ([]*Event, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.event != nil {
+		return []*Event{r.event}, nil
+	}
+	return nil, nil
+}
+
+func (r *testEventRepository) writeEvent(userID string, event *Event) error {
+	return r.err
+}
+
+func (r *testEventRepository) getUserTransferEvents(userID string, transferID TransferID) ([]*Event, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.event != nil {
+		return []*Event{r.event}, nil
+	}
+	return nil, nil
+}
+
 func TestEvents__getUserEvents(t *testing.T) {
 	t.Parallel()
 

--- a/microDeposits.go
+++ b/microDeposits.go
@@ -371,7 +371,7 @@ func addMicroDeposit(file *ach.File, amt Amount) error {
 
 func addMicroDepositWithdraw(file *ach.File, withdrawAmount *Amount) error {
 	// we expect two EntryDetail records (one for each micro-deposit)
-	if file == nil || len(file.Batches) != 1 || len(file.Batches[0].GetEntries()) != 2 {
+	if file == nil || len(file.Batches) != 1 || len(file.Batches[0].GetEntries()) < 1 {
 		return errors.New("invalid micro-deposit ACH file for withdraw")
 	}
 
@@ -381,7 +381,8 @@ func addMicroDepositWithdraw(file *ach.File, withdrawAmount *Amount) error {
 	file.Batches[0].SetHeader(bh)
 
 	// Copy the EntryDetail and replace TransactionCode
-	ed := *file.Batches[0].GetEntries()[1] // copy previous EntryDetail
+	entries := file.Batches[0].GetEntries()
+	ed := *entries[len(entries)-1] // take last entry detail
 	ed.ID = base.ID()[:8]
 	// TransactionCodes seem to follow a simple pattern:
 	//  37 SavingsDebit -> 32 SavingsCredit

--- a/microDeposits.go
+++ b/microDeposits.go
@@ -108,7 +108,7 @@ func (m microDeposit) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func microDepositAmounts() ([]Amount, int) {
+func microDepositAmounts() []Amount {
 	rand := func() int {
 		n, _ := rand.Int(rand.Reader, big.NewInt(49)) // rand.Int returns [0, N) and we want a range of $0.01 to $0.50
 		return int(n.Int64()) + 1
@@ -117,7 +117,7 @@ func microDepositAmounts() ([]Amount, int) {
 	n1, n2 := rand(), rand()
 	a1, _ := NewAmount("USD", fmt.Sprintf("0.%02d", n1)) // pad 1 to '01'
 	a2, _ := NewAmount("USD", fmt.Sprintf("0.%02d", n2))
-	return []Amount{*a1, *a2}, n1 + n2
+	return []Amount{*a1, *a2}
 }
 
 // initiateMicroDeposits will write micro deposits into the underlying database and kick off the ACH transfer(s).
@@ -160,8 +160,8 @@ func (r *DepositoryRouter) initiateMicroDeposits() http.HandlerFunc {
 		}
 
 		// Our Depository needs to be Verified so let's submit some micro deposits to it.
-		amounts, sum := microDepositAmounts()
-		microDeposits, err := r.submitMicroDeposits(userID, requestID, amounts, sum, dep)
+		amounts := microDepositAmounts()
+		microDeposits, err := r.submitMicroDeposits(userID, requestID, amounts, dep)
 		if err != nil {
 			err = fmt.Errorf("problem submitting micro-deposits: %v", err)
 			r.logger.Log("microDeposits", err, "requestID", requestID, "userID", userID)
@@ -248,12 +248,26 @@ func updateMicroDepositsWithTransactionIDs(logger log.Logger, ODFIAccount *ODFIA
 // - Write micro-deposits to SQL table (used in /confirm endpoint)
 //
 // submitMicroDeposits assumes there are 2 amounts to credit and a third to debit.
-func (r *DepositoryRouter) submitMicroDeposits(userID string, requestID string, amounts []Amount, sum int, dep *Depository) ([]*microDeposit, error) {
+func (r *DepositoryRouter) submitMicroDeposits(userID string, requestID string, amounts []Amount, dep *Depository) ([]*microDeposit, error) {
 	odfiOriginator, odfiDepository := r.odfiAccount.metadata()
 
 	// TODO(adam): reject if user has been failed too much verifying this Depository -- w.WriteHeader(http.StatusConflict)
 
 	var microDeposits []*microDeposit
+	withdrawAmount, err := NewAmount("USD", "0.00") // TODO(adam): we need to add a test for the higher level endpoint (or see why no test currently fails)
+	if err != nil {
+		return nil, fmt.Errorf("error with withdrawAmount: %v", err)
+	}
+
+	idempotencyKey := base.ID()
+	rec := &Receiver{
+		ID:       ReceiverID(fmt.Sprintf("%s-micro-deposit-verify", base.ID())),
+		Status:   ReceiverVerified, // Something to pass constructACHFile validation logic
+		Metadata: dep.Holder,       // Depository holder is getting the micro deposit
+	}
+
+	var file *ach.File
+
 	for i := range amounts {
 		req := &transferRequest{
 			Amount:                 amounts[i],
@@ -265,58 +279,65 @@ func (r *DepositoryRouter) submitMicroDeposits(userID string, requestID string, 
 		// micro-deposits must balance, the 3rd amount is the other two's sum
 		if i == 0 || i == 1 {
 			req.Type = PushTransfer
+		}
+		req.Receiver, req.ReceiverDepository = rec.ID, dep.ID
+
+		if file == nil {
+			xfer := req.asTransfer(string(rec.ID))
+			f, err := constructACHFile(string(rec.ID), idempotencyKey, userID, xfer, rec, dep, odfiOriginator, odfiDepository)
+			if err != nil {
+				err = fmt.Errorf("problem constructing ACH file for userID=%s: %v", userID, err)
+				r.logger.Log("microDeposits", err, "requestID", requestID, "userID", userID)
+				return nil, err
+			}
+			file = f
 		} else {
-			req.Type = PullTransfer
+			addMicroDeposit(file, amounts[i])
 		}
 
-		// The Receiver and ReceiverDepository are the Depository that needs approval.
-		req.Receiver = ReceiverID(fmt.Sprintf("%s-micro-deposit-verify", base.ID()))
-		req.ReceiverDepository = dep.ID
-		rec := &Receiver{
-			ID:       req.Receiver,
-			Status:   ReceiverVerified, // Something to pass constructACHFile validation logic
-			Metadata: dep.Holder,       // Depository holder is getting the micro deposit
-		}
-
-		// Convert to Transfer object
-		xfer := req.asTransfer(string(rec.ID))
-
-		// Build and submit the file (with micro-deposits) to moov's ACH service
-		idempotencyKey := base.ID()
-		file, err := constructACHFile(string(xfer.ID), idempotencyKey, userID, xfer, rec, dep, odfiOriginator, odfiDepository)
-		if err != nil {
-			err = fmt.Errorf("problem constructing ACH file for userID=%s: %v", userID, err)
-			r.logger.Log("microDeposits", err, "requestID", requestID, "userID", userID)
-			return nil, err
-		}
 		// We need to withdraw the micro-deposit from the remote account. To do this simply debit that account by adding another EntryDetail
-		addMicroDepositReversal(file)
+		if w, err := withdrawAmount.Plus(amounts[i]); err != nil {
+			return nil, fmt.Errorf("error adding %v to withdraw amount: %v", amounts[i].String(), err)
+		} else {
+			withdrawAmount = &w // Plus returns a new instance, so accumulate it
+		}
 
-		// Submit the ACH file against moov's ACH service.
-		fileID, err := r.achClient.CreateFile(idempotencyKey, file)
-		if err != nil {
-			err = fmt.Errorf("problem creating ACH file for userID=%s: %v", userID, err)
-			r.logger.Log("microDeposits", err, "requestID", requestID, "userID", userID)
-			return nil, err
+		// If we're on the last micro-deposit then append our withdraw transaction
+		if i == len(amounts)-1 {
+			req.Type = PullTransfer // pull: withdraw funds
+
+			// Append our withdraw to a file so it's uploaded to the ODFI
+			if err := addMicroDepositWithdraw(file, withdrawAmount); err != nil {
+				return nil, fmt.Errorf("problem adding withdraw amount: %v", err)
+			}
 		}
-		if err := checkACHFile(r.logger, r.achClient, fileID, userID); err != nil {
-			return nil, err
-		}
-		r.logger.Log("microDeposits", fmt.Sprintf("created ACH file=%s depository=%s", xfer.ID, dep.ID), "requestID", requestID, "userID", userID)
+		microDeposits = append(microDeposits, &microDeposit{amount: amounts[i]})
 
 		// Store the Transfer creation as an event
 		if err := writeTransferEvent(userID, req, r.eventRepo); err != nil {
 			return nil, fmt.Errorf("userID=%s problem writing micro-deposit transfer event: %v", userID, err)
 		}
-
-		microDeposits = append(microDeposits, &microDeposit{
-			amount: amounts[i],
-			fileID: fileID,
-		})
 	}
+
+	// Submit the ACH file against moov's ACH service after adding every micro-deposit
+	fileID, err := r.achClient.CreateFile(idempotencyKey, file)
+	if err != nil {
+		err = fmt.Errorf("problem creating ACH file for userID=%s: %v", userID, err)
+		r.logger.Log("microDeposits", err, "requestID", requestID, "userID", userID)
+		return nil, err
+	}
+	if err := checkACHFile(r.logger, r.achClient, fileID, userID); err != nil {
+		return nil, err
+	}
+	r.logger.Log("microDeposits", fmt.Sprintf("created ACH file=%s for depository=%s", fileID, dep.ID), "requestID", requestID, "userID", userID)
+
+	for i := range microDeposits {
+		microDeposits[i].fileID = fileID
+	}
+
 	// Post the transaction against Accounts only if it's enabled (flagged via nil AccountsClient)
 	if r.accountsClient != nil {
-		transactions, err := updateMicroDepositsWithTransactionIDs(r.logger, r.odfiAccount, r.accountsClient, userID, dep, microDeposits, sum, requestID)
+		transactions, err := updateMicroDepositsWithTransactionIDs(r.logger, r.odfiAccount, r.accountsClient, userID, dep, microDeposits, withdrawAmount.Int(), requestID)
 		if err != nil {
 			return microDeposits, fmt.Errorf("submitMicroDeposits: error posting to Accounts: %v", err)
 		}
@@ -325,9 +346,33 @@ func (r *DepositoryRouter) submitMicroDeposits(userID string, requestID string, 
 	return microDeposits, nil
 }
 
-func addMicroDepositReversal(file *ach.File) {
+func addMicroDeposit(file *ach.File, amt Amount) error {
 	if file == nil || len(file.Batches) != 1 || len(file.Batches[0].GetEntries()) != 1 {
-		return // invalid file
+		return errors.New("invalid micro-deposit ACH file for deposits")
+	}
+
+	// Copy the EntryDetail and replace TransactionCode
+	ed := *file.Batches[0].GetEntries()[0] // copy previous EntryDetail
+	ed.ID = base.ID()[:8]
+
+	// increment trace number
+	if n, _ := strconv.Atoi(ed.TraceNumber); n > 0 {
+		ed.TraceNumber = strconv.Itoa(n + 1)
+	}
+
+	// use our calculated amount to withdraw all micro-deposits
+	ed.Amount = amt.Int()
+
+	// append our new EntryDetail
+	file.Batches[0].AddEntry(&ed)
+
+	return nil
+}
+
+func addMicroDepositWithdraw(file *ach.File, withdrawAmount *Amount) error {
+	// we expect two EntryDetail records (one for each micro-deposit)
+	if file == nil || len(file.Batches) != 1 || len(file.Batches[0].GetEntries()) != 2 {
+		return errors.New("invalid micro-deposit ACH file for withdraw")
 	}
 
 	// We need to adjust ServiceClassCode as this batch has a debit and credit now
@@ -336,7 +381,7 @@ func addMicroDepositReversal(file *ach.File) {
 	file.Batches[0].SetHeader(bh)
 
 	// Copy the EntryDetail and replace TransactionCode
-	ed := *file.Batches[0].GetEntries()[0] // copy the existing EntryDetail
+	ed := *file.Batches[0].GetEntries()[1] // copy previous EntryDetail
 	ed.ID = base.ID()[:8]
 	// TransactionCodes seem to follow a simple pattern:
 	//  37 SavingsDebit -> 32 SavingsCredit
@@ -348,8 +393,13 @@ func addMicroDepositReversal(file *ach.File) {
 		ed.TraceNumber = strconv.Itoa(n + 1)
 	}
 
+	// use our calculated amount to withdraw all micro-deposits
+	ed.Amount = withdrawAmount.Int()
+
 	// append our new EntryDetail
 	file.Batches[0].AddEntry(&ed)
+
+	return nil
 }
 
 type confirmDepositoryRequest struct {

--- a/microDeposits_test.go
+++ b/microDeposits_test.go
@@ -648,13 +648,17 @@ func TestMicroDeposits__addMicroDepositWithdraw(t *testing.T) {
 	withdrawAmount, _ := NewAmount("USD", "0.14") // not $0.12 on purpose
 
 	// nil, so expect no changes
-	addMicroDepositWithdraw(nil, withdrawAmount)
+	if err := addMicroDepositWithdraw(nil, withdrawAmount); err == nil {
+		t.Fatal("expected error")
+	}
 	if len(file.Batches) != 1 || len(file.Batches[0].GetEntries()) != 1 {
 		t.Fatalf("file.Batches[0]=%#v", file.Batches[0])
 	}
 
 	// add reversal batch
-	addMicroDepositWithdraw(file, withdrawAmount)
+	if err := addMicroDepositWithdraw(file, withdrawAmount); err != nil {
+		t.Fatal(err)
+	}
 
 	// verify
 	if len(file.Batches) != 1 {

--- a/microDeposits_test.go
+++ b/microDeposits_test.go
@@ -166,12 +166,13 @@ func TestMicroDeposits__AdminGetMicroDeposits(t *testing.T) {
 
 func TestMicroDeposits__microDepositAmounts(t *testing.T) {
 	for i := 0; i < 100; i++ {
-		amounts, sum := microDepositAmounts()
+		amounts := microDepositAmounts()
 		if len(amounts) != 2 {
 			t.Errorf("got %d micro-deposit amounts", len(amounts))
 		}
-		if v := (amounts[0].Int() + amounts[1].Int()); v != sum {
-			t.Errorf("v=%d sum=%d", v, sum)
+		sum, _ := amounts[0].Plus(amounts[1])
+		if sum.Int() != (amounts[0].Int() + amounts[1].Int()) {
+			t.Errorf("amounts[0]=%s amounts[1]=%s", amounts[0].String(), amounts[1].String())
 		}
 	}
 }
@@ -627,10 +628,11 @@ func readMergedFilename(repo *SQLDepositoryRepo, amount *Amount, id DepositoryID
 	return mergedFilename, nil
 }
 
-func TestMicroDeposits__addMicroDepositReversal(t *testing.T) {
+func TestMicroDeposits__addMicroDepositWithdraw(t *testing.T) {
 	ed := ach.NewEntryDetail()
 	ed.TransactionCode = ach.CheckingCredit
 	ed.TraceNumber = "123"
+	ed.Amount = 12 // $0.12
 
 	bh := ach.NewBatchHeader()
 	bh.StandardEntryClassCode = "PPD"
@@ -643,14 +645,16 @@ func TestMicroDeposits__addMicroDepositReversal(t *testing.T) {
 	file := ach.NewFile()
 	file.AddBatch(batch)
 
+	withdrawAmount, _ := NewAmount("USD", "0.14") // not $0.12 on purpose
+
 	// nil, so expect no changes
-	addMicroDepositReversal(nil)
+	addMicroDepositWithdraw(nil, withdrawAmount)
 	if len(file.Batches) != 1 || len(file.Batches[0].GetEntries()) != 1 {
 		t.Fatalf("file.Batches[0]=%#v", file.Batches[0])
 	}
 
 	// add reversal batch
-	addMicroDepositReversal(file)
+	addMicroDepositWithdraw(file, withdrawAmount)
 
 	// verify
 	if len(file.Batches) != 1 {
@@ -663,11 +667,56 @@ func TestMicroDeposits__addMicroDepositReversal(t *testing.T) {
 	if entries[0].TransactionCode-5 != entries[1].TransactionCode {
 		t.Errorf("entries[0].TransactionCode=%d entries[1].TransactionCode=%d", entries[0].TransactionCode, entries[1].TransactionCode)
 	}
-	if entries[0].Amount != entries[1].Amount {
-		t.Errorf("entries[0].Amount=%d entries[1].Amount=%d", entries[0].Amount, entries[1].Amount)
+	if entries[0].Amount != 12 {
+		t.Errorf("entries[0].Amount=%d", entries[0].Amount)
+	}
+	if entries[1].Amount != 14 {
+		t.Errorf("entries[1].Amount=%d", entries[1].Amount)
 	}
 	if entries[1].TraceNumber != "124" {
 		t.Errorf("entries[1].TraceNumber=%s", entries[1].TraceNumber)
+	}
+}
+
+func TestMicroDeposits_submitMicroDeposits(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	achClient, _, achServer := achclient.MockClientServer("submitMicroDeposits", func(r *mux.Router) {
+		achclient.AddCreateRoute(w, r)
+		achclient.AddValidateRoute(r)
+	})
+	defer achServer.Close()
+
+	testODFIAccount := makeTestODFIAccount()
+
+	router := &DepositoryRouter{
+		logger:      log.NewNopLogger(),
+		achClient:   achClient,
+		eventRepo:   &testEventRepository{},
+		odfiAccount: testODFIAccount,
+	}
+	router.accountsClient = nil // explicitly disable Accounts calls for this test
+	userID, requestID := base.ID(), base.ID()
+
+	amounts := []Amount{
+		{symbol: "USD", number: 12}, // $0.12
+		{symbol: "USD", number: 37}, // $0.37
+	}
+
+	dep := &Depository{
+		ID:            DepositoryID(base.ID()),
+		BankName:      "bank name",
+		Holder:        "holder",
+		HolderType:    Individual,
+		Type:          Checking,
+		RoutingNumber: "121042882",
+		AccountNumber: "151",
+		Status:        DepositoryUnverified,
+	}
+
+	microDeposits, err := router.submitMicroDeposits(userID, requestID, amounts, dep)
+	if n := len(microDeposits); n != 2 || err != nil {
+		t.Fatalf("n=%d error=%v", n, err)
 	}
 }
 


### PR DESCRIPTION
We need to balance micro-deposits made against a remote account, so accumulate those deposits for a final withdraw EntryDetail. Also, we will include the transactions in a single batch to optimize sending over the wire (in byte size and Fed cost).

Issue: https://github.com/moov-io/paygate/issues/244