### PR TITLE
files: separate endpoints for flushing inbound and outbound files

### DIFF
--- a/file_transfer_async_test.go
+++ b/file_transfer_async_test.go
@@ -178,11 +178,12 @@ func TestFileTransferController__startPeriodicFileOperations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	forceUpload := make(chan struct{}, 1)
+	flushIncoming, flushOutgoing := make(chan struct{}, 1), make(chan struct{}, 1)
 	ctx, cancelFileSync := context.WithCancel(context.Background())
 
-	go controller.StartPeriodicFileOperations(ctx, forceUpload, depRepo, transferRepo) // async call to register the polling loop
-	forceUpload <- struct{}{}                                                          // trigger the calls
+	go controller.StartPeriodicFileOperations(ctx, flushIncoming, flushOutgoing, depRepo, transferRepo) // async call to register the polling loop
+	flushIncoming <- struct{}{}                                                                         // trigger the calls
+	flushOutgoing <- struct{}{}
 
 	time.Sleep(250 * time.Millisecond)
 

--- a/file_transfer_async_test.go
+++ b/file_transfer_async_test.go
@@ -321,6 +321,37 @@ func TestFileTransferController__saveRemoteFiles(t *testing.T) {
 		t.Errorf("deleted file was %s", agent.deletedFile)
 	}
 }
+
+func TestFileTransferController__grabAllFiles(t *testing.T) {
+	// grab ACH files from our testdata directory
+	files, err := grabAllFiles("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Error("no ACH files found")
+	}
+	for i := range files {
+		if files[i].File == nil {
+			t.Errorf("files[%d].filepath=%s has nil ach.File", i, files[i].filepath)
+		}
+	}
+
+	// dir with an invalid ACH file
+	dir, err := ioutil.TempDir("", "grabAllFilesErr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "invalid.ach"), []byte("invalid ACH file contents"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err = grabAllFiles(dir)
+	if len(files) != 0 || err == nil {
+		t.Errorf("error=%v files=%#v", err, files)
+	}
+}
+
 func TestFileTransferController__filesNearTheirCutoff(t *testing.T) {
 	nyc, _ := time.LoadLocation("America/New_York")
 	now := time.Now().In(nyc)

--- a/file_transfer_sync_test.go
+++ b/file_transfer_sync_test.go
@@ -13,7 +13,97 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
-func TestForceFileUpload(t *testing.T) {
+func TestFlushIncomingFiles(t *testing.T) {
+	svc := admin.NewServer(":0")
+	go func(t *testing.T) {
+		if err := svc.Listen(); err != nil && err != http.ErrServerClosed {
+			t.Fatal(err)
+		}
+	}(t)
+	defer svc.Shutdown()
+
+	flushIncoming := make(chan struct{}, 1)
+	AddFileTransferSyncRoute(log.NewNopLogger(), svc, flushIncoming, nil)
+
+	// invalid request, wrong HTTP verb
+	req, err := http.NewRequest("GET", "http://localhost"+svc.BindAddr()+"/files/flush/incoming", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("bogus HTTP status: %d", resp.StatusCode)
+	}
+
+	// valid request
+	req, err = http.NewRequest("POST", "http://localhost"+svc.BindAddr()+"/files/flush/incoming", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("bogus HTTP status: %d", resp.StatusCode)
+	}
+
+	<-flushIncoming
+}
+
+func TestFlushOutgoingFiles(t *testing.T) {
+	svc := admin.NewServer(":0")
+	go func(t *testing.T) {
+		if err := svc.Listen(); err != nil && err != http.ErrServerClosed {
+			t.Fatal(err)
+		}
+	}(t)
+	defer svc.Shutdown()
+
+	flushOutgoing := make(chan struct{}, 1)
+	AddFileTransferSyncRoute(log.NewNopLogger(), svc, nil, flushOutgoing)
+
+	// invalid request, wrong HTTP verb
+	req, err := http.NewRequest("GET", "http://localhost"+svc.BindAddr()+"/files/flush/outgoing", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("bogus HTTP status: %d", resp.StatusCode)
+	}
+
+	// valid request
+	req, err = http.NewRequest("POST", "http://localhost"+svc.BindAddr()+"/files/flush/outgoing", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("bogus HTTP status: %d", resp.StatusCode)
+	}
+
+	<-flushOutgoing
+}
+
+func TestFlushFilesUpload(t *testing.T) {
 	svc := admin.NewServer(":0")
 	go func(t *testing.T) {
 		if err := svc.Listen(); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
This change splits the admin endpoint for "flushing" files into two endpoints (and a third for doing both). The change allows operators to have fine grained control over where files are at any given moment. (Useful for tests and tutorials.)

Issue: https://github.com/moov-io/paygate/issues/239