### PR TITLE
micro-deposits: record the transactionID when initiating

### DIFF
--- a/microDeposits.go
+++ b/microDeposits.go
@@ -598,7 +598,7 @@ func (r *SQLDepositoryRepo) initiateMicroDeposits(id DepositoryID, userID string
 		return err
 	}
 
-	now, query := time.Now(), `insert into micro_deposits (depository_id, user_id, amount, file_id, created_at) values (?, ?, ?, ?, ?)`
+	now, query := time.Now(), `insert into micro_deposits (depository_id, user_id, amount, file_id, transaction_id, created_at) values (?, ?, ?, ?, ?, ?)`
 	stmt, err := tx.Prepare(query)
 	if err != nil {
 		return fmt.Errorf("initiateMicroDeposits: prepare error=%v rollback=%v", err, tx.Rollback())
@@ -606,7 +606,7 @@ func (r *SQLDepositoryRepo) initiateMicroDeposits(id DepositoryID, userID string
 	defer stmt.Close()
 
 	for i := range microDeposits {
-		_, err = stmt.Exec(id, userID, microDeposits[i].amount.String(), microDeposits[i].fileID, now)
+		_, err = stmt.Exec(id, userID, microDeposits[i].amount.String(), microDeposits[i].fileID, microDeposits[i].transactionID, now)
 		if err != nil {
 			return fmt.Errorf("initiateMicroDeposits: scan error=%v rollback=%v", err, tx.Rollback())
 		}

--- a/microDeposits_test.go
+++ b/microDeposits_test.go
@@ -325,14 +325,16 @@ func TestMicroDeposits__insertMicroDepositVerify(t *testing.T) {
 		id, userID := DepositoryID(base.ID()), base.ID()
 
 		amt, _ := NewAmount("USD", "0.11")
-		mc := &microDeposit{amount: *amt, fileID: base.ID() + "-micro-deposit-verify"}
+		mc := &microDeposit{
+			amount:        *amt,
+			fileID:        base.ID() + "-micro-deposit-verify",
+			transactionID: "transactionID",
+		}
 		mcs := []*microDeposit{mc}
 
 		if err := repo.initiateMicroDeposits(id, userID, mcs); err != nil {
 			t.Fatal(err)
 		}
-
-		// TODO(adam): verify transactionID is stored and returned
 
 		microDeposits, err := repo.getMicroDepositsForUser(id, userID)
 		if n := len(microDeposits); err != nil || n == 0 {
@@ -340,6 +342,9 @@ func TestMicroDeposits__insertMicroDepositVerify(t *testing.T) {
 		}
 		if m := microDeposits[0]; m.fileID != mc.fileID {
 			t.Errorf("got %s", m.fileID)
+		}
+		if m := microDeposits[0]; m.transactionID != mc.transactionID {
+			t.Errorf("got %s", m.transactionID)
 		}
 	}
 


### PR DESCRIPTION
This was missed before when adding the column, but we are recording it now. 