### PR TITLE
internal/filetransfer: don't panic if micro-deposit Depository isn't found

### DIFF
--- a/internal/filetransfer/return.go
+++ b/internal/filetransfer/return.go
@@ -105,7 +105,7 @@ func (c *Controller) processReturnEntry(fileHeader ach.FileHeader, header *ach.B
 
 	// No Transfer, so maybe a Depository? It could be a micro-deposit.
 	dep, err := depRepo.LookupDepositoryFromReturn(fileHeader.ImmediateDestination, entry.DFIAccountNumber)
-	if err != nil {
+	if dep == nil || err != nil {
 		return fmt.Errorf("problem looking up Depository: %v", err)
 	}
 	microDeposit, err := depRepo.LookupMicroDepositFromReturn(dep.ID, amount)


### PR DESCRIPTION
```
ts=2019-09-30T17:32:01.028945Z caller=return.go:41 processReturnFiles="processing return file return-WEB.ach from ASF APPLICATION SUPERVI (691000134)"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x465d936]

goroutine 12 [running]:
github.com/moov-io/paygate/internal/filetransfer.(*Controller).processReturnEntry(0xc00020e0c0, 0x0, 0x0, 0x4909b4f, 0x1, 0x4909bd6, 0x2, 0xc000235264, 0x9, 0xc00023526e, ...)
	/Users/adam/code/src/github.com/moov-io/paygate/internal/filetransfer/return.go:111 +0x4e6
github.com/moov-io/paygate/internal/filetransfer.(*Controller).processReturnFiles.func1(0xc000074310, 0x63, 0x4a28800, 0xc00008eea0, 0x0, 0x0, 0xe, 0xc0001cfa50)
	/Users/adam/code/src/github.com/moov-io/paygate/internal/filetransfer/return.go:57 +0x606
path/filepath.walk(0xc000074310, 0x63, 0x4a28800, 0xc00008eea0, 0xc0001cfc00, 0x0, 0x0)
	/usr/local/Cellar/go/1.13/libexec/src/path/filepath/path.go:358 +0x425
path/filepath.walk(0xc000234f60, 0x54, 0x4a28800, 0xc00008edd0, 0xc0001cfc00, 0x0, 0x55)
	/usr/local/Cellar/go/1.13/libexec/src/path/filepath/path.go:382 +0x2ff
path/filepath.Walk(0xc000234f60, 0x54, 0xc0001cfc00, 0x417eedf, 0xc000234f60)
	/usr/local/Cellar/go/1.13/libexec/src/path/filepath/path.go:404 +0xff
github.com/moov-io/paygate/internal/filetransfer.(*Controller).processReturnFiles(0xc00020e0c0, 0xc000234f60, 0x54, 0x4a2e3c0, 0xc000123900, 0x4a2ce40, 0xc000123980, 0x0, 0xc00025e1b0)
	/Users/adam/code/src/github.com/moov-io/paygate/internal/filetransfer/return.go:31 +0x9f
github.com/moov-io/paygate/internal/filetransfer.(*Controller).downloadAndProcessIncomingFiles(0xc00020e0c0, 0x4a2e3c0, 0xc000123900, 0x4a2ce40, 0xc000123980, 0x0, 0x0)
	/Users/adam/code/src/github.com/moov-io/paygate/internal/filetransfer/incoming.go:55 +0x9d7
github.com/moov-io/paygate/internal/filetransfer.(*Controller).StartPeriodicFileOperations(0xc00020e0c0, 0x4a24180, 0xc0000d1ec0, 0xc00010c900, 0xc00010c960, 0x4a2e3c0, 0xc000123900, 0x4a2ce40, 0xc000123980)
	/Users/adam/code/src/github.com/moov-io/paygate/internal/filetransfer/controller.go:195 +0x991
created by main.setupFileTransferController
	/Users/adam/code/src/github.com/moov-io/paygate/cmd/server/main.go:283 +0x13c
exit status 2
```