### PR TITLE
internal/filetransfer: simplify Transfer returns Depository lookup

### DIFF
--- a/internal/filetransfer/return.go
+++ b/internal/filetransfer/return.go
@@ -85,10 +85,14 @@ func (c *Controller) processReturnEntry(fileHeader ach.FileHeader, header *ach.B
 		}
 		c.logger.Log("processReturnEntry", fmt.Sprintf("matched traceNumber=%s to transfer=%s with returnCode=%s", entry.TraceNumber, transfer.ID, returnCode), "requestID", requestID)
 
-		// optionally update Status on Depository's related to transfer if the ReturnCode requires
-		origDep, recDep, err := findDepositoriesForFileHeader(transfer.UserID, fileHeader, entry, depRepo)
+		// Grab the full Depository objects for our Transfer
+		origDep, err := depRepo.GetUserDepository(transfer.OriginatorDepository, transfer.UserID)
 		if err != nil {
-			return fmt.Errorf("error finding depositories: %v", err)
+			return fmt.Errorf("processTransferReturn: error finding originator depository=%s: %v", transfer.OriginatorDepository, err)
+		}
+		recDep, err := depRepo.GetUserDepository(transfer.ReceiverDepository, transfer.UserID)
+		if err != nil {
+			return fmt.Errorf("processTransferReturn: error finding receiver depository=%s: %v", transfer.ReceiverDepository, err)
 		}
 		c.logger.Log("processReturnEntry", fmt.Sprintf("found deposiories for transfer=%s (originator=%s) (receiver=%s)", transfer.ID, origDep.ID, recDep.ID), "requestID", requestID)
 

--- a/internal/filetransfer/returned_transfers.go
+++ b/internal/filetransfer/returned_transfers.go
@@ -33,36 +33,3 @@ func (c *Controller) processTransferReturn(requestID string, transfer *internal.
 
 	return nil
 }
-
-func findDepositoriesForFileHeader(userID string, fileHeader ach.FileHeader, entry *ach.EntryDetail, depRepo internal.DepositoryRepository) (*internal.Depository, *internal.Depository, error) {
-	deps, err := depRepo.GetUserDepositories(userID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("problem finding user Depository objects: %v", err)
-	}
-
-	// Find Originator and Receiver Depository objects
-	var origDep *internal.Depository
-	var recDep *internal.Depository
-	for k := range deps {
-		if deps[k].Status != internal.DepositoryVerified {
-			continue // We only allow Verified Depositories
-		}
-		if fileHeader.ImmediateOrigin == deps[k].RoutingNumber { // TODO(adam): Should we match the originator's account number?
-			origDep = deps[k] // Originator Depository matched
-		}
-		if deps[k].RoutingNumber == fileHeader.ImmediateDestination && deps[k].AccountNumber == entry.DFIAccountNumber {
-			recDep = deps[k] // Receiver Depository matched
-		}
-	}
-	if origDep == nil || recDep == nil {
-		p := func(d *internal.Depository) string {
-			if d == nil {
-				return ""
-			} else {
-				return string(d.ID)
-			}
-		}
-		return nil, nil, fmt.Errorf("depository not found origDep=%q recDep=%q", p(origDep), p(recDep))
-	}
-	return origDep, recDep, nil
-}

--- a/internal/filetransfer/returned_transfers_test.go
+++ b/internal/filetransfer/returned_transfers_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/moov-io/ach"
 	"github.com/moov-io/base"
 	"github.com/moov-io/paygate/internal"
 
@@ -110,50 +109,4 @@ func TestController__processReturnTransfer(t *testing.T) {
 		t.Error("expected error")
 	}
 	transferRepo.Err = nil
-}
-
-func TestReturns__findDepositoriesForFileHeader(t *testing.T) {
-	depID := internal.DepositoryID(base.ID())
-	repo := &internal.MockDepositoryRepository{
-		Depositories: []*internal.Depository{
-			{
-				ID:            internal.DepositoryID(depID),
-				AccountNumber: "123512",
-				RoutingNumber: "987654320",
-				Status:        internal.DepositoryVerified,
-			},
-			{
-				ID:            internal.DepositoryID(base.ID()),
-				AccountNumber: "7777",
-				RoutingNumber: "123456789",
-				Status:        internal.DepositoryVerified,
-			},
-		},
-	}
-
-	fh := ach.NewFileHeader()
-	fh.ImmediateOrigin = "987654320"
-	fh.ImmediateDestination = "123456789"
-
-	ed := ach.NewEntryDetail()
-	ed.DFIAccountNumber = "7777"
-
-	userID := base.ID()
-	origDep, recDep, err := findDepositoriesForFileHeader(userID, fh, ed, repo)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if origDep.ID != depID {
-		t.Errorf("origDep=%#v", origDep)
-	}
-	if recDep.ID != repo.Depositories[1].ID {
-		t.Errorf("recDep.ID=%#v", recDep)
-	}
-
-	// not found case
-	repo.Depositories = nil
-	origDep, recDep, err = findDepositoriesForFileHeader(userID, fh, ed, repo)
-	if origDep != nil || recDep != nil || err == nil {
-		t.Errorf("expected error: origDep=%#v recDep=%#v", origDep, recDep)
-	}
 }


### PR DESCRIPTION
We don't need to inspect the ACH File / EntryDetail to match a users
depositories against. Instead this information exists on the Transfer
that's already matched.