### PR TITLE
internal/filetransfer: allow synchronous waiting for flush routes

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -277,7 +277,7 @@ func setupFileTransferController(logger log.Logger, controller *filetransfer.Con
 		return cancelFileSync
 	}
 
-	flushIncoming, flushOutgoing := make(chan struct{}, 1), make(chan struct{}, 1) // buffered channels to allow only one concurrent operation
+	flushIncoming, flushOutgoing := make(filetransfer.FlushChan, 1), make(filetransfer.FlushChan, 1) // buffered channels to allow only one concurrent operation
 
 	// start our controller's operations in an anon goroutine
 	go controller.StartPeriodicFileOperations(ctx, flushIncoming, flushOutgoing, depRepo, transferRepo)

--- a/docs/ach.md
+++ b/docs/ach.md
@@ -67,6 +67,8 @@ There are endpoints for just inbound or outbound file processing:
 - `POST /files/flush/incoming`
 - `POST /files/flush/outgoing`
 
+Note: The query parameter `?wait` can be added onto any endpoint to hold the HTTP response until file operations are done. This has the potential of returning a timeout however, and the file operations will continue.
+
 Note: These endpoints currently return no information in the HTTP response and instead inspect paygate's logs for details.
 
 ### Returned ACH Files

--- a/internal/filetransfer/admin.go
+++ b/internal/filetransfer/admin.go
@@ -7,57 +7,95 @@ package filetransfer
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/moov-io/base/admin"
 	moovhttp "github.com/moov-io/base/http"
+	"github.com/moov-io/paygate/internal/util"
 
 	"github.com/go-kit/kit/log"
 )
 
-func AddFileTransferSyncRoute(logger log.Logger, svc *admin.Server, flushIncoming chan struct{}, flushOutgoing chan struct{}) {
+func AddFileTransferSyncRoute(logger log.Logger, svc *admin.Server, flushIncoming FlushChan, flushOutgoing FlushChan) {
 	svc.AddHandler("/files/flush/incoming", flushIncomingFiles(logger, flushIncoming))
 	svc.AddHandler("/files/flush/outgoing", flushOutgoingFiles(logger, flushOutgoing))
 	svc.AddHandler("/files/flush", flushFiles(logger, flushIncoming, flushOutgoing))
 }
 
 // flushIncomingFiles will download inbound and return files and then process them
-func flushIncomingFiles(logger log.Logger, flushIncoming chan struct{}) http.HandlerFunc {
+func flushIncomingFiles(logger log.Logger, flushIncoming FlushChan) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			moovhttp.Problem(w, fmt.Errorf("unsupported HTTP verb %s", r.Method))
 			return
 		}
 
-		flushIncoming <- struct{}{} // send a message on the channel to trigger async routine
-
+		req := maybeWaiter(r)
+		flushIncoming <- req
+		if err := maybeWait(w, req); err == util.ErrTimeout {
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	}
 }
 
 // flushOutgoingFiles will merge and upload outbound files
-func flushOutgoingFiles(logger log.Logger, flushOutgoing chan struct{}) http.HandlerFunc {
+func flushOutgoingFiles(logger log.Logger, flushOutgoing FlushChan) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			moovhttp.Problem(w, fmt.Errorf("unsupported HTTP verb %s", r.Method))
 			return
 		}
 
-		flushOutgoing <- struct{}{} // send a message on the channel to trigger async routine
-
+		req := maybeWaiter(r)
+		flushOutgoing <- req
+		if err := maybeWait(w, req); err == util.ErrTimeout {
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	}
 }
 
-func flushFiles(logger log.Logger, flushIncoming chan struct{}, flushOutgoing chan struct{}) http.HandlerFunc {
+func flushFiles(logger log.Logger, flushIncoming FlushChan, flushOutgoing FlushChan) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			moovhttp.Problem(w, fmt.Errorf("unsupported HTTP verb %s", r.Method))
 			return
 		}
 
-		flushIncoming <- struct{}{}
-		flushOutgoing <- struct{}{}
-
+		reqIncoming, reqOutgoing := maybeWaiter(r), maybeWaiter(r)
+		flushIncoming <- reqIncoming
+		flushOutgoing <- reqOutgoing
+		if err := maybeWait(w, reqIncoming); err == util.ErrTimeout {
+			return
+		}
+		if err := maybeWait(w, reqOutgoing); err == util.ErrTimeout {
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	}
+}
+
+func maybeWaiter(r *http.Request) *periodicFileOperationsRequest {
+	if _, exists := r.URL.Query()["wait"]; exists {
+		return &periodicFileOperationsRequest{
+			waiter: make(chan struct{}, 1),
+		}
+	}
+	return &periodicFileOperationsRequest{}
+}
+
+func maybeWait(w http.ResponseWriter, req *periodicFileOperationsRequest) error {
+	if req.waiter != nil {
+		err := util.Timeout(func() error {
+			<-req.waiter // wait for a response from StartPeriodicFileOperations
+			return nil
+		}, 30*time.Second)
+
+		if err == util.ErrTimeout {
+			moovhttp.Problem(w, err)
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/filetransfer/admin_test.go
+++ b/internal/filetransfer/admin_test.go
@@ -22,7 +22,7 @@ func TestFlushIncomingFiles(t *testing.T) {
 	}(t)
 	defer svc.Shutdown()
 
-	flushIncoming := make(chan struct{}, 1)
+	flushIncoming := make(FlushChan, 1)
 	AddFileTransferSyncRoute(log.NewNopLogger(), svc, flushIncoming, nil)
 
 	// invalid request, wrong HTTP verb
@@ -67,7 +67,7 @@ func TestFlushOutgoingFiles(t *testing.T) {
 	}(t)
 	defer svc.Shutdown()
 
-	flushOutgoing := make(chan struct{}, 1)
+	flushOutgoing := make(FlushChan, 1)
 	AddFileTransferSyncRoute(log.NewNopLogger(), svc, nil, flushOutgoing)
 
 	// invalid request, wrong HTTP verb
@@ -112,7 +112,7 @@ func TestFlushFilesUpload(t *testing.T) {
 	}(t)
 	defer svc.Shutdown()
 
-	flushIncoming, flushOutgoing := make(chan struct{}, 1), make(chan struct{}, 1) // buffered channel
+	flushIncoming, flushOutgoing := make(FlushChan, 1), make(FlushChan, 1) // buffered channel
 	AddFileTransferSyncRoute(log.NewNopLogger(), svc, flushIncoming, flushOutgoing)
 
 	req, err := http.NewRequest("POST", "http://"+svc.BindAddr()+"/files/flush", nil)

--- a/internal/filetransfer/controller_test.go
+++ b/internal/filetransfer/controller_test.go
@@ -172,12 +172,13 @@ func TestController__startPeriodicFileOperations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	flushIncoming, flushOutgoing := make(chan struct{}, 1), make(chan struct{}, 1)
+	flushIncoming, flushOutgoing := make(FlushChan, 1), make(FlushChan, 1)
 	ctx, cancelFileSync := context.WithCancel(context.Background())
 
 	go controller.StartPeriodicFileOperations(ctx, flushIncoming, flushOutgoing, depRepo, transferRepo) // async call to register the polling loop
-	flushIncoming <- struct{}{}                                                                         // trigger the calls
-	flushOutgoing <- struct{}{}
+	// trigger the calls
+	flushIncoming <- &periodicFileOperationsRequest{}
+	flushOutgoing <- &periodicFileOperationsRequest{}
 
 	time.Sleep(250 * time.Millisecond)
 


### PR DESCRIPTION
Often for testing it's helpful to hang until the file operations are completed (processing inbound and outboud files) rather than a fixed sleep and retry cycle.

Issue: https://github.com/moov-io/paygate/issues/276