### PR TITLE
filetransfer: read configs from database rather than once at startup

### DIFF
--- a/internal/filetransfer/config_test.go
+++ b/internal/filetransfer/config_test.go
@@ -38,6 +38,79 @@ func createTestSQLiteRepository(t *testing.T) *testSQLRepository {
 	return &testSQLRepository{repo, db}
 }
 
+type mockRepository struct {
+	configs     []*Config
+	cutoffTimes []*CutoffTime
+	ftpConfigs  []*FTPConfig
+	sftpConfigs []*SFTPConfig
+
+	err error
+}
+
+func (r *mockRepository) GetConfigs() ([]*Config, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.configs, nil
+}
+
+func (r *mockRepository) upsertConfig(cfg *Config) error {
+	return r.err
+}
+
+func (r *mockRepository) deleteConfig(routingNumber string) error {
+	return r.err
+}
+
+func (r *mockRepository) GetCutoffTimes() ([]*CutoffTime, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.cutoffTimes, nil
+}
+
+func (r *mockRepository) upsertCutoffTime(routingNumber string, cutoff int, loc *time.Location) error {
+	return r.err
+}
+
+func (r *mockRepository) deleteCutoffTime(routingNumber string) error {
+	return r.err
+}
+
+func (r *mockRepository) GetFTPConfigs() ([]*FTPConfig, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.ftpConfigs, nil
+}
+
+func (r *mockRepository) upsertFTPConfigs(routingNumber, host, user, pass string) error {
+	return r.err
+}
+
+func (r *mockRepository) deleteFTPConfig(routingNumber string) error {
+	return r.err
+}
+
+func (r *mockRepository) GetSFTPConfigs() ([]*SFTPConfig, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.sftpConfigs, nil
+}
+
+func (r *mockRepository) upsertSFTPConfigs(routingNumber, host, user, pass, privateKey, publicKey string) error {
+	return r.err
+}
+
+func (r *mockRepository) deleteSFTPConfig(routingNumber string) error {
+	return r.err
+}
+
+func (r *mockRepository) Close() error {
+	return r.err
+}
+
 func TestSQLiteRepository__getCounts(t *testing.T) {
 	repo := createTestSQLiteRepository(t)
 	defer repo.Close()

--- a/internal/filetransfer/controller_test.go
+++ b/internal/filetransfer/controller_test.go
@@ -43,14 +43,25 @@ func TestController(t *testing.T) {
 	if controller.batchSize != 100 {
 		t.Errorf("batchSize: %d", controller.batchSize)
 	}
-	if len(controller.cutoffTimes) != 1 {
-		t.Errorf("local len(controller.cutoffTimes)=%d", len(controller.cutoffTimes))
+
+	cutoffTimes, err := controller.repo.GetCutoffTimes()
+	if len(cutoffTimes) != 1 || err != nil {
+		t.Errorf("local len(cutoffTimes)=%d error=%v", len(cutoffTimes), err)
 	}
-	if len(controller.sftpConfigs) != 0 {
-		t.Errorf("local len(controller.sftpConfigs)=%d", len(controller.sftpConfigs))
+	ftpConfigs, err := controller.repo.GetFTPConfigs()
+	if len(ftpConfigs) != 1 || err != nil {
+		t.Errorf("local len(ftpConfigs)=%d error=%v", len(ftpConfigs), err)
 	}
-	if len(controller.fileTransferConfigs) != 1 {
-		t.Errorf("local len(controller.fileTransferConfigs)=%d", len(controller.fileTransferConfigs))
+
+	// force the localFileTransferRepository into SFTP mode
+	if r, ok := controller.repo.(*localFileTransferRepository); ok {
+		r.transferType = "sftp"
+	} else {
+		t.Fatalf("got %#v", controller.repo)
+	}
+	sftpConfigs, err := controller.repo.GetSFTPConfigs()
+	if len(sftpConfigs) != 1 || err != nil {
+		t.Errorf("local len(sftpConfigs)=%d error=%v", len(sftpConfigs), err)
 	}
 }
 
@@ -61,24 +72,14 @@ func TestController__findFileTransferConfig(t *testing.T) {
 		Loc:           time.UTC,
 	}
 	controller := &Controller{
-		ftpConfigs: []*FTPConfig{
-			{
-				RoutingNumber: "123",
-				Hostname:      "ftp.foo.com",
+		repo: &mockRepository{
+			configs: []*Config{
+				{RoutingNumber: "123", InboundPath: "inbound/"},
+				{RoutingNumber: "321", InboundPath: "incoming/"},
 			},
-			{
-				RoutingNumber: "321",
-				Hostname:      "ftp.bar.com",
-			},
-		},
-		fileTransferConfigs: []*Config{
-			{
-				RoutingNumber: "123",
-				InboundPath:   "inbound/",
-			},
-			{
-				RoutingNumber: "321",
-				InboundPath:   "incoming/",
+			ftpConfigs: []*FTPConfig{
+				{RoutingNumber: "123", Hostname: "ftp.foo.com"},
+				{RoutingNumber: "321", Hostname: "ftp.bar.com"},
 			},
 		},
 	}
@@ -100,7 +101,9 @@ func TestController__findFileTransferConfig(t *testing.T) {
 }
 
 func TestController__findTransferType(t *testing.T) {
-	controller := &Controller{}
+	controller := &Controller{
+		repo: &mockRepository{},
+	}
 
 	if v := controller.findTransferType(""); v != "unknown" {
 		t.Errorf("got %s", v)
@@ -110,17 +113,25 @@ func TestController__findTransferType(t *testing.T) {
 	}
 
 	// Get 'sftp' as type
-	controller.sftpConfigs = append(controller.sftpConfigs, &SFTPConfig{
-		RoutingNumber: "987654320",
-	})
+	controller = &Controller{
+		repo: &mockRepository{
+			sftpConfigs: []*SFTPConfig{
+				{RoutingNumber: "987654320"},
+			},
+		},
+	}
 	if v := controller.findTransferType("987654320"); v != "sftp" {
 		t.Errorf("got %s", v)
 	}
 
 	// 'ftp' is checked first, so let's override that now
-	controller.ftpConfigs = append(controller.ftpConfigs, &FTPConfig{
-		RoutingNumber: "987654320",
-	})
+	controller = &Controller{
+		repo: &mockRepository{
+			ftpConfigs: []*FTPConfig{
+				{RoutingNumber: "987654320"},
+			},
+		},
+	}
 	if v := controller.findTransferType("987654320"); v != "ftp" {
 		t.Errorf("got %s", v)
 	}

--- a/internal/filetransfer/outgoing.go
+++ b/internal/filetransfer/outgoing.go
@@ -169,7 +169,11 @@ func (c *Controller) mergeAndUploadFiles(transferCur *internal.TransferCursor, m
 		filesToUpload = files // upload everything found
 	} else {
 		// Find files close to their cutoff to enqueue
-		toUpload, err := filesNearTheirCutoff(c.cutoffTimes, mergedDir)
+		cutoffTimes, err := c.repo.GetCutoffTimes()
+		if err != nil {
+			return fmt.Errorf("cutoff times: %v", err)
+		}
+		toUpload, err := filesNearTheirCutoff(cutoffTimes, mergedDir)
 		if err != nil {
 			return fmt.Errorf("problem with filesNearTheirCutoff: %v", err)
 		}

--- a/internal/filetransfer/outgoing_test.go
+++ b/internal/filetransfer/outgoing_test.go
@@ -169,10 +169,12 @@ func TestController__mergeTransfer(t *testing.T) {
 	// call .mergeTransfer
 	controller := &Controller{
 		logger: log.NewNopLogger(),
-		fileTransferConfigs: []*Config{
-			{
-				RoutingNumber:            "091400606",
-				OutboundFilenameTemplate: defaultFilenameTemplate,
+		repo: &mockRepository{
+			configs: []*Config{
+				{
+					RoutingNumber:            "091400606",
+					OutboundFilenameTemplate: defaultFilenameTemplate,
+				},
 			},
 		},
 	}
@@ -228,10 +230,12 @@ func TestController__mergeGroupableTransfer(t *testing.T) {
 	controller := &Controller{
 		ach:    achClient,
 		logger: log.NewNopLogger(),
-		fileTransferConfigs: []*Config{
-			{
-				RoutingNumber:            "076401251",
-				OutboundFilenameTemplate: defaultFilenameTemplate,
+		repo: &mockRepository{
+			configs: []*Config{
+				{
+					RoutingNumber:            "076401251",
+					OutboundFilenameTemplate: defaultFilenameTemplate,
+				},
 			},
 		},
 	}
@@ -288,10 +292,12 @@ func TestController__mergeMicroDeposit(t *testing.T) {
 	controller := &Controller{
 		ach:    achClient,
 		logger: log.NewNopLogger(),
-		fileTransferConfigs: []*Config{
-			{
-				RoutingNumber:            "987654320",
-				OutboundFilenameTemplate: defaultFilenameTemplate,
+		repo: &mockRepository{
+			configs: []*Config{
+				{
+					RoutingNumber:            "987654320",
+					OutboundFilenameTemplate: defaultFilenameTemplate,
+				},
 			},
 		},
 	}
@@ -338,20 +344,22 @@ func TestController__mergeMicroDeposit(t *testing.T) {
 func TestController__startUploadError(t *testing.T) {
 	nyc, _ := time.LoadLocation("America/New_York")
 	controller := &Controller{
-		cutoffTimes: []*CutoffTime{
-			{
-				RoutingNumber: "987654320",
-				Cutoff:        1700,
-				Loc:           nyc,
-			},
-		},
-		fileTransferConfigs: []*Config{
-			{
-				RoutingNumber: "987654320",
-				OutboundPath:  "outbound/",
-			},
-		},
 		logger: log.NewNopLogger(),
+		repo: &mockRepository{
+			cutoffTimes: []*CutoffTime{
+				{
+					RoutingNumber: "987654320",
+					Cutoff:        1700,
+					Loc:           nyc,
+				},
+			},
+			configs: []*Config{
+				{
+					RoutingNumber: "987654320",
+					OutboundPath:  "outbound/",
+				},
+			},
+		},
 	}
 
 	// Setup our test file for upload
@@ -455,10 +463,12 @@ func TestController__grabLatestMergedACHFile(t *testing.T) {
 	}
 	controller := &Controller{
 		logger: log.NewNopLogger(),
-		fileTransferConfigs: []*Config{
-			{
-				RoutingNumber:            origin,
-				OutboundFilenameTemplate: defaultFilenameTemplate,
+		repo: &mockRepository{
+			configs: []*Config{
+				{
+					RoutingNumber:            origin,
+					OutboundFilenameTemplate: defaultFilenameTemplate,
+				},
 			},
 		},
 	}
@@ -491,10 +501,16 @@ func TestController__grabLatestMergedACHFile(t *testing.T) {
 	}
 
 	// Add a new file_transfer_config
-	controller.fileTransferConfigs = append(controller.fileTransferConfigs, &Config{
-		RoutingNumber: incoming.Header.ImmediateDestination,
-	})
-
+	controller = &Controller{
+		logger: log.NewNopLogger(),
+		repo: &mockRepository{
+			configs: []*Config{
+				{
+					RoutingNumber: incoming.Header.ImmediateDestination,
+				},
+			},
+		},
+	}
 	file, err = controller.grabLatestMergedACHFile(incoming.Header.ImmediateDestination, incoming, dir)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Previously we read all configs at startup, but then never refreshed those configs. Instead let's read whenever we need the config so updates in the database happen they are picked up.