### PR TITLE
filetransfer: write filenames with their destination, not origin

### DIFF
--- a/internal/filetransfer/outgoing_test.go
+++ b/internal/filetransfer/outgoing_test.go
@@ -244,7 +244,7 @@ func TestController__mergeGroupableTransfer(t *testing.T) {
 		Transfer: &internal.Transfer{
 			ID: internal.TransferID(base.ID()),
 		},
-		Origin: "076401251", // from testdata/ppd-debit.ach
+		Destination: "076401251", // from testdata/ppd-debit.ach
 	}
 
 	db := database.CreateTestSqliteDB(t)
@@ -263,7 +263,7 @@ func TestController__mergeGroupableTransfer(t *testing.T) {
 	}
 
 	// check our mergable files
-	mergableFile, err := controller.grabLatestMergedACHFile(xfer.Origin, file, dir)
+	mergableFile, err := controller.grabLatestMergedACHFile(xfer.Destination, file, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,19 +406,19 @@ func TestController__groupTransfers(t *testing.T) {
 			Transfer: &internal.Transfer{
 				ID: "1",
 			},
-			Origin: "123456789",
+			Destination: "123456789",
 		},
 		{
 			Transfer: &internal.Transfer{
 				ID: "2",
 			},
-			Origin: "123456789",
+			Destination: "123456789",
 		},
 		{
 			Transfer: &internal.Transfer{
 				ID: "3",
 			},
-			Origin: "987654321",
+			Destination: "987654321",
 		},
 	}
 	grouped, err := groupTransfers(transfers, nil)

--- a/internal/transfers.go
+++ b/internal/transfers.go
@@ -929,9 +929,9 @@ type TransferCursor struct {
 type GroupableTransfer struct {
 	*Transfer
 
-	// Origin is the ABA routing number of the Originating FI (ODFI)
-	// This comes from the Transfer's OriginatorDepository.RoutingNumber
-	Origin string
+	// Destination is the ABA routing number of the Destination FI (DFI)
+	// This comes from the Transfer's ReceiverDepository.RoutingNumber
+	Destination string
 
 	userID string
 }
@@ -982,14 +982,14 @@ func (cur *TransferCursor) Next() ([]*GroupableTransfer, error) {
 		if err != nil {
 			continue
 		}
-		originDep, err := cur.DepRepo.GetUserDepository(t.OriginatorDepository, xfers[i].userID)
-		if err != nil || originDep == nil {
+		destDep, err := cur.DepRepo.GetUserDepository(t.ReceiverDepository, xfers[i].userID)
+		if err != nil || destDep == nil {
 			continue
 		}
 		transfers = append(transfers, &GroupableTransfer{
-			Transfer: t,
-			Origin:   originDep.RoutingNumber,
-			userID:   xfers[i].userID,
+			Transfer:    t,
+			Destination: destDep.RoutingNumber,
+			userID:      xfers[i].userID,
 		})
 		if xfers[i].createdAt.After(max) {
 			max = xfers[i].createdAt // advance max to newest time

--- a/internal/transfers_test.go
+++ b/internal/transfers_test.go
@@ -1079,7 +1079,7 @@ func TestTransfers_MarkTransferAsMerged(t *testing.T) {
 		Type:          Checking,
 		RoutingNumber: "123",
 		AccountNumber: "151",
-		Status:        DepositoryUnverified,
+		Status:        DepositoryVerified,
 		Created:       base.NewTime(time.Now().Add(-1 * time.Second)),
 	}
 	if err := depRepo.UpsertUserDepository(userID, dep); err != nil {
@@ -1097,9 +1097,9 @@ func TestTransfers_MarkTransferAsMerged(t *testing.T) {
 			Type:                   PushTransfer,
 			Amount:                 amt("12.12"),
 			Originator:             OriginatorID("originator1"),
-			OriginatorDepository:   dep.ID, // ReceiverDepository is read from a depositoryRepository
+			OriginatorDepository:   DepositoryID("originator1"),
 			Receiver:               ReceiverID("receiver1"),
-			ReceiverDepository:     DepositoryID("receiver1"),
+			ReceiverDepository:     dep.ID, // ReceiverDepository is read from a depositoryRepository
 			Description:            "money1",
 			StandardEntryClassCode: "PPD",
 			fileID:                 "test-file1",
@@ -1134,9 +1134,9 @@ func TestTransfers_MarkTransferAsMerged(t *testing.T) {
 			Type:                   PullTransfer,
 			Amount:                 amt("13.13"),
 			Originator:             OriginatorID("originator2"),
-			OriginatorDepository:   dep.ID,
+			OriginatorDepository:   DepositoryID("originator2"),
 			Receiver:               ReceiverID("receiver2"),
-			ReceiverDepository:     DepositoryID("receiver2"),
+			ReceiverDepository:     dep.ID,
 			Description:            "money2",
 			StandardEntryClassCode: "PPD",
 			fileID:                 "test-file2",
@@ -1154,6 +1154,7 @@ func TestTransfers_MarkTransferAsMerged(t *testing.T) {
 		for i := range firstBatch {
 			t.Errorf("firstBatch[%d].ID=%v amount=%v", i, firstBatch[i].ID, firstBatch[i].Amount.String())
 		}
+		t.Fatalf("firstBatch: %#v", firstBatch)
 	}
 	if firstBatch[0].Amount.String() != "USD 13.13" {
 		t.Errorf("got %v", firstBatch[0].Amount.String())


### PR DESCRIPTION
Outbound files should be named according to their destination routing
number as there will be multiple of those, but perhaps only one
origin.

All files are uploaded to the ODFI, but from there they're routed
based on the ach.FileHeader's ImmediateDestination. Let's name files
with the same logic.