### PR TITLE
filetransfer: reject file uploads if they're not whitelisted 

### DIFF
--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -129,6 +129,10 @@ var (
 			"add_account_number_hashed_to_depositories",
 			"alter table depositories add column account_number_hashed varchar(64) default'';",
 		),
+		execsql(
+			"add_allowed_ips_to_file_transfer_configs",
+			"alter table file_transfer_configs add column allowed_ips varchar(160) default '';",
+		),
 	)
 )
 

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -123,6 +123,10 @@ var (
 			"add_account_number_hashed_to_depositories",
 			"alter table depositories add column account_number_hashed default'';",
 		),
+		execsql(
+			"add_allowed_ips_to_file_transfer_configs",
+			"alter table file_transfer_configs add column allowed_ips default '';",
+		),
 	)
 )
 

--- a/internal/filetransfer/config.go
+++ b/internal/filetransfer/config.go
@@ -108,7 +108,7 @@ func (r *sqlRepository) GetCounts() (int, int, int) {
 }
 
 func (r *sqlRepository) GetConfigs() ([]*Config, error) {
-	query := `select routing_number, inbound_path, outbound_path, return_path, outbound_filename_template from file_transfer_configs;`
+	query := `select routing_number, inbound_path, outbound_path, return_path, outbound_filename_template, allowed_ips from file_transfer_configs;`
 	stmt, err := r.db.Prepare(query)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func (r *sqlRepository) GetConfigs() ([]*Config, error) {
 	defer rows.Close()
 	for rows.Next() {
 		var cfg Config
-		if err := rows.Scan(&cfg.RoutingNumber, &cfg.InboundPath, &cfg.OutboundPath, &cfg.ReturnPath, &cfg.OutboundFilenameTemplate); err != nil {
+		if err := rows.Scan(&cfg.RoutingNumber, &cfg.InboundPath, &cfg.OutboundPath, &cfg.ReturnPath, &cfg.OutboundFilenameTemplate, &cfg.AllowedIPs); err != nil {
 			return nil, fmt.Errorf("GetConfigs: scan: %v", err)
 		}
 		configs = append(configs, &cfg)

--- a/internal/filetransfer/config_test.go
+++ b/internal/filetransfer/config_test.go
@@ -221,7 +221,7 @@ func TestSQLiteRepository__GetFTPConfigs(t *testing.T) {
 func writeFileTransferConfig(t *testing.T, db *sql.DB) {
 	t.Helper()
 
-	query := `insert into file_transfer_configs (routing_number, inbound_path, outbound_path, return_path) values ('123456789', 'inbound/', 'outbound/', 'return/');`
+	query := `insert into file_transfer_configs (routing_number, inbound_path, outbound_path, return_path, allowed_ips) values ('123456789', 'inbound/', 'outbound/', 'return/', '127.0.0.0/8');`
 	stmt, err := db.Prepare(query)
 	if err != nil {
 		t.Fatal(err)
@@ -258,6 +258,9 @@ func TestSQLiteRepository__GetConfigs(t *testing.T) {
 	if configs[0].ReturnPath != "return/" {
 		t.Errorf("got %q", configs[0].ReturnPath)
 	}
+	if configs[0].AllowedIPs != "127.0.0.0/8" {
+		t.Errorf("got %q", configs[0].AllowedIPs)
+	}
 }
 
 func TestMySQLFileTransferRepository(t *testing.T) {
@@ -287,6 +290,9 @@ func TestMySQLFileTransferRepository(t *testing.T) {
 	}
 	if configs[0].ReturnPath != "return/" {
 		t.Errorf("got %q", configs[0].ReturnPath)
+	}
+	if configs[0].AllowedIPs != "127.0.0.0/8" {
+		t.Errorf("got %q", configs[0].AllowedIPs)
 	}
 
 	testdb.Close()

--- a/internal/filetransfer/controller_test.go
+++ b/internal/filetransfer/controller_test.go
@@ -267,6 +267,10 @@ func (a *mockFileTransferAgent) Delete(path string) error {
 	return nil
 }
 
+func (a *mockFileTransferAgent) hostname() string {
+	return "moov.io"
+}
+
 func (a *mockFileTransferAgent) InboundPath() string  { return "inbound/" }
 func (a *mockFileTransferAgent) OutboundPath() string { return "outbound/" }
 func (a *mockFileTransferAgent) ReturnPath() string   { return "return/" }

--- a/internal/filetransfer/file_transfer.go
+++ b/internal/filetransfer/file_transfer.go
@@ -23,6 +23,8 @@ type Config struct {
 	ReturnPath   string `json:"returnPath" yaml:"returnPath"`
 
 	OutboundFilenameTemplate string `json:"outboundFilenameTemplate" yaml:"outboundFilenameTemplate"`
+
+	AllowedIPs string
 }
 
 func (cfg *Config) outboundFilenameTemplate() string {
@@ -47,6 +49,8 @@ type Agent interface {
 	GetReturnFiles() ([]File, error)
 	UploadFile(f File) error
 	Delete(path string) error
+
+	hostname() string
 
 	InboundPath() string
 	OutboundPath() string

--- a/internal/filetransfer/ftp.go
+++ b/internal/filetransfer/ftp.go
@@ -68,7 +68,17 @@ type FTPTransferAgent struct {
 	mu sync.Mutex // protects all read/write methods
 }
 
+func (a *FTPTransferAgent) hostname() string {
+	if cfg := a.findConfig(); cfg != nil {
+		return cfg.Hostname
+	}
+	return ""
+}
+
 func (a *FTPTransferAgent) findConfig() *FTPConfig {
+	if a == nil {
+		return nil
+	}
 	for i := range a.ftpConfigs {
 		if a.ftpConfigs[i].RoutingNumber == a.cfg.RoutingNumber {
 			return a.ftpConfigs[i]

--- a/internal/filetransfer/ftp_test.go
+++ b/internal/filetransfer/ftp_test.go
@@ -170,6 +170,24 @@ func TestFTPAgent(t *testing.T) {
 	}
 }
 
+func TestFTPAgent__hostname(t *testing.T) {
+	agent := &FTPTransferAgent{
+		cfg: &Config{
+			RoutingNumber: "987654320",
+		},
+		ftpConfigs: []*FTPConfig{
+			{
+				RoutingNumber: "987654320",
+				Hostname:      "ftp.bank.com",
+			},
+		},
+	}
+
+	if v := agent.hostname(); v != "ftp.bank.com" {
+		t.Errorf("got %s", v)
+	}
+}
+
 func TestFTP__tlsDialOption(t *testing.T) {
 	if testing.Short() {
 		return // skip network calls

--- a/internal/filetransfer/outgoing.go
+++ b/internal/filetransfer/outgoing.go
@@ -346,7 +346,7 @@ func rejectOutboundIPRange(cfg *Config, hostname string) error {
 
 	addrs, err := net.LookupIP(hostname)
 	if len(addrs) == 0 || err != nil {
-		fmt.Errorf("unable to resolve (found %d) %s: %v", len(addrs), hostname, err)
+		return fmt.Errorf("unable to resolve (found %d) %s: %v", len(addrs), hostname, err)
 	}
 
 	ips := strings.Split(cfg.AllowedIPs, ",")

--- a/internal/filetransfer/outgoing_test.go
+++ b/internal/filetransfer/outgoing_test.go
@@ -566,4 +566,18 @@ func TestOutgoing__rejectOutboundIPRange(t *testing.T) {
 	if err := rejectOutboundIPRange(cfg, "moov.io"); err != nil {
 		t.Errorf("expected no error: %v", err)
 	}
+
+	// error cases
+	cfg.AllowedIPs = "afkjsafkjahfa"
+	if err := rejectOutboundIPRange(cfg, "moov.io"); err == nil {
+		t.Error("expected error")
+	}
+	cfg.AllowedIPs = "10.0.0.0/8"
+	if err := rejectOutboundIPRange(cfg, "lsjafkshfaksjfhas"); err == nil {
+		t.Error("expected error")
+	}
+	cfg.AllowedIPs = "10...../8"
+	if err := rejectOutboundIPRange(cfg, "moov.io"); err == nil {
+		t.Error("expected error")
+	}
 }

--- a/internal/filetransfer/sftp.go
+++ b/internal/filetransfer/sftp.go
@@ -87,6 +87,13 @@ type SFTPTransferAgent struct {
 	mu sync.Mutex // protects all read/write methods
 }
 
+func (a *SFTPTransferAgent) hostname() string {
+	if cfg := a.findConfig(); cfg != nil {
+		return cfg.Hostname
+	}
+	return ""
+}
+
 func (a *SFTPTransferAgent) findConfig() *SFTPConfig {
 	for i := range a.sftpConfigs {
 		if a.sftpConfigs[i].RoutingNumber == a.cfg.RoutingNumber {

--- a/internal/filetransfer/sftp_test.go
+++ b/internal/filetransfer/sftp_test.go
@@ -376,7 +376,14 @@ func TestSFTP__sftpConnect(t *testing.T) {
 func TestSFTPAgent(t *testing.T) {
 	agent := &SFTPTransferAgent{
 		cfg: &Config{
-			InboundPath: "inbound",
+			RoutingNumber: "987654320",
+			InboundPath:   "inbound",
+		},
+		sftpConfigs: []*SFTPConfig{
+			{
+				RoutingNumber: "987654320",
+				Hostname:      "sftp.bank.com",
+			},
 		},
 	}
 	if v := agent.InboundPath(); v != "inbound" {
@@ -386,6 +393,10 @@ func TestSFTPAgent(t *testing.T) {
 	agent.cfg.ReturnPath = "return"
 	if v := agent.ReturnPath(); v != "return" {
 		t.Errorf("agent.ReturnPath()=%s", agent.ReturnPath())
+	}
+
+	if v := agent.hostname(); v != "sftp.bank.com" {
+		t.Errorf("got %s", v)
 	}
 }
 


### PR DESCRIPTION
This change adds functionality into paygate to reject uploads if they don't match an optional IP/CIDR whitelist.

Docs: https://docs.moov.io/paygate/ach/#ip-whitelisting

Fixes: https://github.com/moov-io/paygate/issues/330