### PR TITLE
transfers: add one day limit, remove routing number check

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ See [our detailed documentation for FTP and SFTP configurations](https://docs.mo
 
 | Environmental Variable | Description | Default |
 |-----|-----|-----|
-| `TRANSFERS_ONE_DAY_LIMIT` | Maximum sum of transfers for each user over the current day. | `5000.00` |
-| `TRANSFERS_SEVEN_DAY_LIMIT` | Maximum sum of transfers for each user over the previous seven days. | `10000.00` |
-| `TRANSFERS_THIRTY_DAY_LIMIT` | Maximum sum of transfers for each user over the previous seven days. | `25000.00` |
+| `TRANSFERS_ONE_DAY_USER_LIMIT` | Maximum sum of transfers for each user over the current day. | `5000.00` |
+| `TRANSFERS_SEVEN_DAY_USER_LIMIT` | Maximum sum of transfers for each user over the previous seven days. | `10000.00` |
+| `TRANSFERS_THIRTY_DAY_USER_LIMIT` | Maximum sum of transfers for each user over the previous seven days. | `25000.00` |
 
 #### Inbound / Returned File Processing
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ See [our detailed documentation for FTP and SFTP configurations](https://docs.mo
 
 | Environmental Variable | Description | Default |
 |-----|-----|-----|
-| `TRANSFERS_SEVEN_DAY_SOFT_LIMIT` | Maximum sum of transfers for each user over the previous seven days. | `10000.00` |
-| `TRANSFERS_THIRTY_DAY_SOFT_LIMIT` | Maximum sum of transfers for each user over the previous seven days. | `25000.00` |
+| `TRANSFERS_ONE_DAY_LIMIT` | Maximum sum of transfers for each user over the current day. | `5000.00` |
+| `TRANSFERS_SEVEN_DAY_LIMIT` | Maximum sum of transfers for each user over the previous seven days. | `10000.00` |
+| `TRANSFERS_THIRTY_DAY_LIMIT` | Maximum sum of transfers for each user over the previous seven days. | `25000.00` |
 
 #### Inbound / Returned File Processing
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -185,7 +185,7 @@ func main() {
 	depositoryRouter.RegisterRoutes(handler)
 
 	// Transfer HTTP routes
-	limits, err := transfers.ParseLimits(transfers.SevenDayLimit(), transfers.ThirtyDayLimit())
+	limits, err := transfers.ParseLimits(transfers.OneDayLimit(), transfers.SevenDayLimit(), transfers.ThirtyDayLimit())
 	if err != nil {
 		panic(fmt.Sprintf("ERROR parsing transfer limits: %v", err))
 	}

--- a/internal/transfers/limits.go
+++ b/internal/transfers/limits.go
@@ -175,13 +175,14 @@ func (lc *LimitChecker) underLimits(userID id.User, routingNumber string, limit 
 		return fmt.Errorf("limits: previous %d days of user transfers would be over: %v", daysAgo, err)
 	}
 
-	total, err = lc.routingNumberSum(routingNumber, newerThan)
-	if err != nil {
-		return fmt.Errorf("limits: error getting %d day routing number total: %v", daysAgo, err)
-	}
-	if err := overLimit(total, limit); err != nil {
-		return fmt.Errorf("limits: previous %d days of transfers for routing number would be over: %v", daysAgo, err)
-	}
+	// TODO(adam): The limit for a routing number needs to be different configs
+	// total, err = lc.routingNumberSum(routingNumber, newerThan)
+	// if err != nil {
+	// 	return fmt.Errorf("limits: error getting %d day routing number total: %v", daysAgo, err)
+	// }
+	// if err := overLimit(total, limit); err != nil {
+	// 	return fmt.Errorf("limits: previous %d days of transfers for routing number would be over: %v", daysAgo, err)
+	// }
 
 	return nil
 }

--- a/internal/transfers/limits.go
+++ b/internal/transfers/limits.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/moov-io/paygate/internal/database"
 	"github.com/moov-io/paygate/internal/model"
+	"github.com/moov-io/paygate/internal/util"
 	"github.com/moov-io/paygate/pkg/id"
 
 	"github.com/go-kit/kit/log"
@@ -21,26 +22,17 @@ import (
 
 // OneDayLimit returns the maximum sum of transfers for each user over the current day.
 func OneDayLimit() string {
-	if v := os.Getenv("TRANSFERS_ONE_DAY_LIMIT"); v != "" {
-		return v
-	}
-	return "5000.00"
+	return util.Or(os.Getenv("TRANSFERS_ONE_DAY_USER_LIMIT"), "5000.00")
 }
 
 // SevenDayLimit returns the maximum sum of transfers for each user over the previous seven days.
 func SevenDayLimit() string {
-	if v := os.Getenv("TRANSFERS_SEVEN_DAY_LIMIT"); v != "" {
-		return v
-	}
-	return "10000.00"
+	return util.Or(os.Getenv("TRANSFERS_SEVEN_DAY_USER_LIMIT"), "10000.00")
 }
 
 // ThirtyDayLimit returns the maximum sum of transfers for each user over the previous thirty days.
 func ThirtyDayLimit() string {
-	if v := os.Getenv("TRANSFERS_THIRTY_DAY_LIMIT"); v != "" {
-		return v
-	}
-	return "25000.00"
+	return util.Or(os.Getenv("TRANSFERS_THIRTY_DAY_USER_LIMIT"), "25000.00")
 }
 
 // ParseLimits attempts to convert multiple strings into Amount objects.

--- a/internal/transfers/limits_test.go
+++ b/internal/transfers/limits_test.go
@@ -16,9 +16,12 @@ import (
 )
 
 func TestLimits__ParseLimits(t *testing.T) {
-	if limits, err := ParseLimits(SevenDayLimit(), ThirtyDayLimit()); err != nil {
+	if limits, err := ParseLimits(OneDayLimit(), SevenDayLimit(), ThirtyDayLimit()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else {
+		if limits.CurrentDay.Int() != 5000*100 {
+			t.Errorf("got %v", limits.CurrentDay)
+		}
 		if limits.PreviousSevenDays.Int() != 10000*100 {
 			t.Errorf("got %v", limits.PreviousSevenDays)
 		}
@@ -27,9 +30,12 @@ func TestLimits__ParseLimits(t *testing.T) {
 		}
 	}
 
-	if limits, err := ParseLimits("1000.00", "123456.00"); err != nil {
+	if limits, err := ParseLimits("100.00", "1000.00", "123456.00"); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else {
+		if limits.CurrentDay.Int() != 100*100 {
+			t.Errorf("got %v", limits.CurrentDay)
+		}
 		if limits.PreviousSevenDays.Int() != 1000*100 {
 			t.Errorf("got %v", limits.PreviousSevenDays)
 		}
@@ -38,9 +44,12 @@ func TestLimits__ParseLimits(t *testing.T) {
 		}
 	}
 
-	if limits, err := ParseLimits("10.00", "1.21"); err != nil {
+	if limits, err := ParseLimits("1.00", "10.00", "1.21"); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else {
+		if limits.CurrentDay.Int() != 1*100 {
+			t.Errorf("got %v", limits.CurrentDay)
+		}
 		if limits.PreviousSevenDays.Int() != 10*100 {
 			t.Errorf("got %v", limits.PreviousSevenDays)
 		}
@@ -51,11 +60,15 @@ func TestLimits__ParseLimits(t *testing.T) {
 }
 
 func TestLimits__ParseLimitsErr(t *testing.T) {
-	if l, err := ParseLimits(SevenDayLimit(), "invalid"); err == nil {
+	if l, err := ParseLimits(OneDayLimit(), SevenDayLimit(), "invalid"); err == nil {
 		t.Logf("%v", l)
 		t.Error("expected error")
 	}
-	if l, err := ParseLimits("invalid", ThirtyDayLimit()); err == nil {
+	if l, err := ParseLimits("invalid", SevenDayLimit(), ThirtyDayLimit()); err == nil {
+		t.Logf("%v", l)
+		t.Error("expected error")
+	}
+	if l, err := ParseLimits(OneDayLimit(), "invalid", ThirtyDayLimit()); err == nil {
 		t.Logf("%v", l)
 		t.Error("expected error")
 	}
@@ -70,7 +83,7 @@ func TestLimits__overLimit(t *testing.T) {
 func TestLimits__integration(t *testing.T) {
 	t.Parallel()
 
-	limits, err := ParseLimits("100.00", "250.00")
+	limits, err := ParseLimits("100.00", "100.00", "250.00")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/transfers/limits_test.go
+++ b/internal/transfers/limits_test.go
@@ -89,10 +89,10 @@ func TestLimits__integration(t *testing.T) {
 	}
 
 	check := func(t *testing.T, lc *LimitChecker) {
-		userID, routingNumber := id.User(base.ID()), "121042882"
+		userID := id.User(base.ID())
 
 		// no transfers yet
-		if err := lc.allowTransfer(userID, routingNumber); err != nil {
+		if err := lc.allowTransfer(userID); err != nil {
 			t.Fatal(err)
 		}
 
@@ -133,7 +133,7 @@ func TestLimits__integration(t *testing.T) {
 		}
 
 		// ensure it's blocked
-		if err := lc.allowTransfer(userID, routingNumber); err == nil {
+		if err := lc.allowTransfer(userID); err == nil {
 			t.Fatal("expected error")
 		}
 		if total, err := lc.userTransferSum(userID, time.Now().Add(-24*time.Hour)); err != nil {
@@ -158,6 +158,5 @@ func TestLimits__integration(t *testing.T) {
 
 	lc = NewLimitChecker(log.NewNopLogger(), mysqlDB.DB, limits)
 	lc.userTransferSumSQL = mysqlSumUserTransfers
-	lc.routingNumberTransferSumSQL = mysqlSumTransfersByRoutingNumber
 	check(t, lc)
 }

--- a/internal/transfers/transfers.go
+++ b/internal/transfers/transfers.go
@@ -289,7 +289,7 @@ func (c *TransferRouter) createUserTransfers() http.HandlerFunc {
 
 			// Check limits for this userID and destination
 			// TODO(adam): We'll need user level limit overrides
-			if err := c.transferLimitChecker.allowTransfer(responder.XUserID, receiverDep.RoutingNumber); err != nil {
+			if err := c.transferLimitChecker.allowTransfer(responder.XUserID); err != nil {
 				responder.Log("transfers", fmt.Sprintf("rejecting transfers: %v", err))
 				responder.Problem(err)
 				return

--- a/internal/transfers/transfers_test.go
+++ b/internal/transfers/transfers_test.go
@@ -57,7 +57,7 @@ func CreateTestTransferRouter(
 	routes ...func(*mux.Router), // test ACH server routes
 ) *testTransferRouter {
 
-	limits, _ := ParseLimits(SevenDayLimit(), ThirtyDayLimit())
+	limits, _ := ParseLimits(OneDayLimit(), SevenDayLimit(), ThirtyDayLimit())
 
 	var db *sql.DB
 	if rr, ok := xfr.(*SQLRepo); ok {
@@ -313,9 +313,10 @@ func TestTransfers__rejectedViaLimits(t *testing.T) {
 	router.accountsClient = nil
 	router.TransferRouter.accountsClient = nil
 
-	// fake like we've sent $11k already, need a weird query...
+	// fake like we've sent money already, need a weird query...
 	router.TransferRouter.transferLimitChecker.userTransferSumSQL = `select 34000.00 where "a" <> ? or "b" <> ?;`
 	router.TransferRouter.transferLimitChecker.routingNumberTransferSumSQL = `select 1 where "a" <> ? or "b" <> ?;`
+	router.TransferRouter.transferLimitChecker.limits.CurrentDay, _ = model.NewAmount("USD", "35000.00")
 
 	if total, err := router.TransferRouter.transferLimitChecker.userTransferSum(id.User("fake"), time.Now()); err != nil {
 		t.Fatal(err)
@@ -350,7 +351,7 @@ func TestTransfers__rejectedViaLimits(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("bogus HTTP statu codes: %d: %s", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "previous seven days") {
+	if !strings.Contains(w.Body.String(), "previous 7 days") {
 		t.Errorf("unexpected error: %v", w.Body.String())
 	}
 }

--- a/internal/transfers/transfers_test.go
+++ b/internal/transfers/transfers_test.go
@@ -315,7 +315,6 @@ func TestTransfers__rejectedViaLimits(t *testing.T) {
 
 	// fake like we've sent money already, need a weird query...
 	router.TransferRouter.transferLimitChecker.userTransferSumSQL = `select 34000.00 where "a" <> ? or "b" <> ?;`
-	router.TransferRouter.transferLimitChecker.routingNumberTransferSumSQL = `select 1 where "a" <> ? or "b" <> ?;`
 	router.TransferRouter.transferLimitChecker.limits.CurrentDay, _ = model.NewAmount("USD", "35000.00")
 
 	if total, err := router.TransferRouter.transferLimitChecker.userTransferSum(id.User("fake"), time.Now()); err != nil {


### PR DESCRIPTION
The check for a destination routing number is a bit harder to monitor as certain ABA's will have lots of transfers (big 5) and others will have small amounts. Let's re-think how to check this inside of paygate's hot code path of transfers. 

Fixes: https://github.com/moov-io/paygate/issues/383 