### PR TITLE
cmd/server: read env variable to disable Fed calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The following environmental variables can be set to configure behavior in paygat
 | `CUSTOMERS_ENDPOINT` | A DNS record responsible for routing us to a [Customers](https://github.com/moov-io/customers) instance. | `http://customers.apps.svc.cluster.local:8080` |
 | `CUSTOMERS_CALLS_DISABLED=yes` | Flag to completely disable all calls to a Customers service. This is used when paygate doesn't need to integrate with a KYC/CIP solution. | `no` |
 | `FED_ENDPOINT` | HTTP address for [FED](https://github.com/moov-io/fed) interaction to lookup ABA routing numbers. | `http://fed.apps.svc.cluster.local:8080` |
+| `FED_CALLS_DISABLED=yes` | Flag to completely disable all calls to Fed service. This is used by paygate to verify routing numbers. | `no` |
 | `HTTP_ADMIN_BIND_ADDRESS` | Address for paygate to bind its admin HTTP server on. This overrides the command-line flag `-admin.addr`. | `:9092` |
 | `HTTP_BIND_ADDRESS` | Address for paygate to bind its HTTP server on. This overrides the command-line flag `-http.addr`. | `:8082` |
 | `HTTP_CLIENT_CAFILE` | Filepath for additional (CA) certificates to be added into each `http.Client` used within paygate. | Empty |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -138,7 +138,7 @@ func main() {
 
 	// Create our various Client instances
 	achClient := setupACHClient(cfg.Logger, os.Getenv("ACH_ENDPOINT"), adminServer, httpClient)
-	fedClient := setupFEDClient(cfg.Logger, os.Getenv("FED_ENDPOINT"), adminServer, httpClient)
+	fedClient := setupFEDClient(cfg.Logger, os.Getenv("FED_ENDPOINT"), os.Getenv("FED_CALLS_DISABLED"), adminServer, httpClient)
 
 	// Bring up our Accounts Client
 	accountsClient := setupAccountsClient(cfg.Logger, adminServer, httpClient, os.Getenv("ACCOUNTS_ENDPOINT"), os.Getenv("ACCOUNTS_CALLS_DISABLED"))
@@ -296,7 +296,10 @@ func setupOFACRefresher(cfg *config.Config, client customers.Client, db *sql.DB)
 	return refresher
 }
 
-func setupFEDClient(logger log.Logger, endpoint string, svc *admin.Server, httpClient *http.Client) fed.Client {
+func setupFEDClient(logger log.Logger, endpoint string, disabled string, svc *admin.Server, httpClient *http.Client) fed.Client {
+	if util.Yes(disabled) {
+		return nil
+	}
 	client := fed.NewClient(logger, endpoint, httpClient)
 	if client == nil {
 		panic("no FED client created")

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -108,9 +108,14 @@ func TestMain__setupFEDClient(t *testing.T) {
 	svc := admin.NewServer(":0")
 	httpClient := &http.Client{}
 
-	client := setupFEDClient(logger, "", svc, httpClient)
+	client := setupFEDClient(logger, "", "", svc, httpClient)
 	if client == nil {
 		t.Error("expected FED client")
+	}
+
+	client = setupFEDClient(logger, "", "yes", svc, httpClient)
+	if client != nil {
+		t.Errorf("expected no FED client=%#v", client)
 	}
 }
 

--- a/internal/depository/router.go
+++ b/internal/depository/router.go
@@ -226,12 +226,11 @@ func (r *Router) createUserDepository() http.HandlerFunc {
 			return
 		}
 
-		// TODO(adam): We should check and reject duplicate Depositories (by ABA and AccountNumber) on creation
-
 		// Check FED for the routing number
 		if r.fedClient != nil {
 			if err := r.fedClient.LookupRoutingNumber(req.routingNumber); err != nil {
-				responder.Log("depositories", fmt.Sprintf("problem with FED routing number lookup %q: %v", req.routingNumber, err.Error()))
+				err = fmt.Errorf("problem with FED routing number lookup %q: %v", req.routingNumber, err)
+				responder.Log("depositories", err)
 				responder.Problem(err)
 				return
 			}

--- a/internal/depository/router.go
+++ b/internal/depository/router.go
@@ -229,10 +229,12 @@ func (r *Router) createUserDepository() http.HandlerFunc {
 		// TODO(adam): We should check and reject duplicate Depositories (by ABA and AccountNumber) on creation
 
 		// Check FED for the routing number
-		if err := r.fedClient.LookupRoutingNumber(req.routingNumber); err != nil {
-			responder.Log("depositories", fmt.Sprintf("problem with FED routing number lookup %q: %v", req.routingNumber, err.Error()))
-			responder.Problem(err)
-			return
+		if r.fedClient != nil {
+			if err := r.fedClient.LookupRoutingNumber(req.routingNumber); err != nil {
+				responder.Log("depositories", fmt.Sprintf("problem with FED routing number lookup %q: %v", req.routingNumber, err.Error()))
+				responder.Problem(err)
+				return
+			}
 		}
 
 		if err := r.depositoryRepo.UpsertUserDepository(responder.XUserID, depository); err != nil {


### PR DESCRIPTION
With options to disable Accounts and Customers we can offer a way to disable Fed calls. At least until something like #427 is implemented in PayGate. 

@wadearnold is this too dangerous to expose? Clients would need to understand the risk of returns (and their cost) from disabling this and sending invalid routing numbers. 