### PR TITLE
filetransfer: mark Transfers as Processed only immediately on upload

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -165,7 +165,7 @@ func main() {
 	microDepositRepo := microdeposit.NewRepository(cfg.Logger, db)
 
 	achStorageDir := setupACHStorageDir(cfg.Logger)
-	fileTransferController, err := filetransfer.NewController(cfg, achStorageDir, fileTransferRepo, achClient, accountsClient)
+	fileTransferController, err := filetransfer.NewController(cfg, achStorageDir, fileTransferRepo, depositoryRepo, microDepositRepo, transferRepo, achClient, accountsClient)
 	if err != nil {
 		panic(fmt.Sprintf("ERROR: creating ACH file transfer controller: %v", err))
 	}
@@ -350,7 +350,7 @@ func setupFileTransferController(
 	flushIncoming, flushOutgoing := make(filetransfer.FlushChan, 1), make(filetransfer.FlushChan, 1) // buffered channels to allow only one concurrent operation
 
 	// start our controller's operations in an anon goroutine
-	go controller.StartPeriodicFileOperations(ctx, flushIncoming, flushOutgoing, depRepo, microDepositRepo, transferRepo)
+	go controller.StartPeriodicFileOperations(ctx, flushIncoming, flushOutgoing)
 
 	filetransfer.AddFileTransferConfigRoutes(logger, svc, fileTransferRepo)
 	filetransfer.AddFileTransferSyncRoute(logger, svc, flushIncoming, flushOutgoing)

--- a/internal/filetransfer/controller_test.go
+++ b/internal/filetransfer/controller_test.go
@@ -42,7 +42,7 @@ func TestController(t *testing.T) {
 	repo := NewRepository("", nil, "")
 
 	cfg := config.Empty()
-	controller, err := NewController(cfg, dir, repo, nil, nil)
+	controller, err := NewController(cfg, dir, repo, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestController__startPeriodicFileOperations(t *testing.T) {
 
 	// setup transfer controller to start a manual merge and upload
 	cfg := config.Empty()
-	controller, err := NewController(cfg, dir, repo, achClient, nil)
+	controller, err := NewController(cfg, dir, repo, innerDepRepo, microDepositRepo, transferRepo, achClient, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +227,7 @@ func TestController__startPeriodicFileOperations(t *testing.T) {
 	flushIncoming, flushOutgoing := make(FlushChan, 1), make(FlushChan, 1)
 	ctx, cancelFileSync := context.WithCancel(context.Background())
 
-	go controller.StartPeriodicFileOperations(ctx, flushIncoming, flushOutgoing, innerDepRepo, microDepositRepo, transferRepo) // async call to register the polling loop
+	go controller.StartPeriodicFileOperations(ctx, flushIncoming, flushOutgoing) // async call to register the polling loop
 	// trigger the calls
 	flushIncoming <- &periodicFileOperationsRequest{}
 	flushOutgoing <- &periodicFileOperationsRequest{}

--- a/internal/filetransfer/files.go
+++ b/internal/filetransfer/files.go
@@ -1,0 +1,25 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package filetransfer
+
+import (
+	"github.com/moov-io/ach"
+)
+
+func collectTraceNumbers(f *ach.File) []string {
+	var out []string
+	for i := range f.Batches {
+		entries := f.Batches[i].GetEntries()
+		for k := range entries {
+			out = append(out, entries[k].TraceNumber)
+		}
+	}
+	for i := range f.IATBatches {
+		for k := range f.IATBatches[i].Entries {
+			out = append(out, f.IATBatches[i].Entries[k].TraceNumber)
+		}
+	}
+	return out
+}

--- a/internal/filetransfer/files_test.go
+++ b/internal/filetransfer/files_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package filetransfer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/moov-io/ach"
+)
+
+func readACHFile(path string) (*ach.File, error) {
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("problem reading %s: %v", path, err)
+	}
+	defer fd.Close()
+
+	file, err := ach.NewReader(fd).Read()
+	if err != nil {
+		return nil, fmt.Errorf("problem parsing %s: %v", path, err)
+	}
+	return &file, nil
+}
+
+func TestFiles__collectTraceNumbers(t *testing.T) {
+	// this file has multiple trace numbers
+	file, err := readACHFile(filepath.Join("..", "..", "testdata", "return-WEB.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	traceNumbers := collectTraceNumbers(file)
+	sort.Strings(traceNumbers)
+
+	expected := []string{"021000029461242", "091000017611242"}
+
+	if len(traceNumbers) != len(expected) {
+		t.Errorf("got %d trace numbers expected %d", len(traceNumbers), len(expected))
+	}
+	for i := range traceNumbers {
+		if traceNumbers[i] != expected[i] {
+			t.Errorf("#%d got=%q expected=%q", i, traceNumbers[i], expected[i])
+		}
+	}
+}

--- a/internal/filetransfer/outgoing.go
+++ b/internal/filetransfer/outgoing.go
@@ -384,6 +384,13 @@ func (c *Controller) startUpload(filesToUpload []*achFile) error {
 	for i := range filesToUpload {
 		file := filesToUpload[i]
 
+		// Update transfer statuses prior to upload, we won't re-collect a Transfer from the transfers.Cursor after this.
+		if n, err := c.transferRepo.MarkTransfersAsProcessed(filepath.Base(file.filepath), collectTraceNumbers(file.File)); err != nil {
+			return fmt.Errorf("problem marking transfers as processed for file=%s: %v", file.filepath, err)
+		} else {
+			c.logger.Log("transfers", fmt.Sprintf("marked %d transfers as processed for file=%s", n, file.filepath))
+		}
+
 		if err := c.maybeUploadFile(file); err != nil {
 			return fmt.Errorf("problem uploading %s: %v", file.filepath, err)
 		}

--- a/internal/filetransfer/outgoing_test.go
+++ b/internal/filetransfer/outgoing_test.go
@@ -246,6 +246,9 @@ func TestController__mergeGroupableTransfer(t *testing.T) {
 				},
 			},
 		},
+		transferRepo: &transfers.MockRepository{
+			FileID: "foo", // some non-empty value, our test ACH server doesn't care
+		},
 	}
 
 	xfer := &transfers.GroupableTransfer{
@@ -258,9 +261,7 @@ func TestController__mergeGroupableTransfer(t *testing.T) {
 	db := database.CreateTestSqliteDB(t)
 	defer db.Close()
 
-	repo := &transfers.MockRepository{}
-	repo.FileID = "foo" // some non-empty value, our test ACH server doesn't care
-	if fileToUpload := controller.mergeGroupableTransfer(dir, xfer, repo); fileToUpload != nil {
+	if fileToUpload := controller.mergeGroupableTransfer(dir, xfer); fileToUpload != nil {
 		t.Errorf("didn't expect fileToUpload=%v", fileToUpload)
 	}
 
@@ -297,6 +298,12 @@ func TestController__mergeMicroDeposit(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
+	db := database.CreateTestSqliteDB(t)
+	defer db.Close()
+
+	keeper := secrets.TestStringKeeper(t)
+	microDepositRepo := microdeposit.NewRepository(log.NewNopLogger(), db.DB)
+
 	controller := &Controller{
 		ach:    achClient,
 		logger: log.NewNopLogger(),
@@ -308,14 +315,9 @@ func TestController__mergeMicroDeposit(t *testing.T) {
 				},
 			},
 		},
+		depRepo:          depository.NewDepositoryRepo(log.NewNopLogger(), db.DB, keeper),
+		microDepositRepo: microDepositRepo,
 	}
-
-	db := database.CreateTestSqliteDB(t)
-	defer db.Close()
-
-	keeper := secrets.TestStringKeeper(t)
-	depRepo := depository.NewDepositoryRepo(log.NewNopLogger(), db.DB, keeper)
-	microDepositRepo := microdeposit.NewRepository(log.NewNopLogger(), db.DB)
 
 	// Setup our micro-deposit
 	amt, _ := model.NewAmount("USD", "0.22")
@@ -330,7 +332,7 @@ func TestController__mergeMicroDeposit(t *testing.T) {
 	}
 
 	// write a Depository
-	if err := depRepo.UpsertUserDepository("userID", &model.Depository{
+	if err := controller.depRepo.UpsertUserDepository("userID", &model.Depository{
 		ID:            "depositoryID",
 		BankName:      "Mooc, Inc",
 		RoutingNumber: "987654320",
@@ -338,7 +340,7 @@ func TestController__mergeMicroDeposit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if fileToUpload := controller.mergeMicroDeposit(dir, mc, depRepo, microDepositRepo); fileToUpload != nil {
+	if fileToUpload := controller.mergeMicroDeposit(dir, mc); fileToUpload != nil {
 		t.Errorf("didn't expect an ACH file to upload: %#v", fileToUpload)
 	}
 

--- a/internal/filetransfer/outgoing_test.go
+++ b/internal/filetransfer/outgoing_test.go
@@ -372,6 +372,7 @@ func TestController__startUploadError(t *testing.T) {
 				},
 			},
 		},
+		transferRepo: &transfers.MockRepository{},
 	}
 
 	// Setup our test file for upload

--- a/internal/filetransfer/returned_micro_deposits.go
+++ b/internal/filetransfer/returned_micro_deposits.go
@@ -12,8 +12,8 @@ import (
 	"github.com/moov-io/paygate/pkg/id"
 )
 
-func (c *Controller) processMicroDepositReturn(requestID string, userID id.User, depID id.Depository, mc *microdeposit.Credit, repo microdeposit.Repository, code *ach.ReturnCode) error {
-	if err := repo.SetReturnCode(depID, mc.Amount, code.Code); err != nil {
+func (c *Controller) processMicroDepositReturn(requestID string, userID id.User, depID id.Depository, mc *microdeposit.Credit, code *ach.ReturnCode) error {
+	if err := c.microDepositRepo.SetReturnCode(depID, mc.Amount, code.Code); err != nil {
 		return fmt.Errorf("problem setting micro-deposit code=%s: %v", code.Code, err)
 	}
 

--- a/internal/filetransfer/returned_micro_deposits_test.go
+++ b/internal/filetransfer/returned_micro_deposits_test.go
@@ -74,12 +74,12 @@ func TestController__processReturnMicroDeposit(t *testing.T) {
 	repo := NewRepository("", nil, "")
 
 	cfg := config.Empty()
-	controller, err := NewController(cfg, dir, repo, nil, nil)
+	controller, err := NewController(cfg, dir, repo, depRepo, microDepositRepo, transferRepo, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0], depRepo, microDepositRepo, transferRepo); err != nil {
+	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0]); err != nil {
 		t.Error(err)
 	}
 
@@ -96,13 +96,13 @@ func TestController__processReturnMicroDeposit(t *testing.T) {
 
 	// Check quick error conditions
 	depRepo.Err = errors.New("bad error")
-	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0], depRepo, microDepositRepo, transferRepo); err == nil {
+	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0]); err == nil {
 		t.Error("expected error")
 	}
 	depRepo.Err = nil
 
 	transferRepo.Err = errors.New("bad error")
-	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0], depRepo, microDepositRepo, transferRepo); err == nil {
+	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0]); err == nil {
 		t.Error("expected error")
 	}
 	transferRepo.Err = nil

--- a/internal/filetransfer/returned_transfers_test.go
+++ b/internal/filetransfer/returned_transfers_test.go
@@ -81,13 +81,13 @@ func TestController__processReturnTransfer(t *testing.T) {
 	repo := NewRepository("", nil, "")
 
 	cfg := config.Empty()
-	controller, err := NewController(cfg, dir, repo, nil, nil)
+	controller, err := NewController(cfg, dir, repo, depRepo, microDepositRepo, transferRepo, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// transferRepo.xfer will be returned inside processReturnEntry and the Transfer path will be executed
-	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0], depRepo, microDepositRepo, transferRepo); err != nil {
+	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0]); err != nil {
 		t.Error(err)
 	}
 
@@ -104,13 +104,13 @@ func TestController__processReturnTransfer(t *testing.T) {
 
 	// Check quick error conditions
 	depRepo.Err = errors.New("bad error")
-	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0], depRepo, microDepositRepo, transferRepo); err == nil {
+	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0]); err == nil {
 		t.Error("expected error")
 	}
 	depRepo.Err = nil
 
 	transferRepo.Err = errors.New("bad error")
-	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0], depRepo, microDepositRepo, transferRepo); err == nil {
+	if err := controller.processReturnEntry(file.Header, b.GetHeader(), b.GetEntries()[0]); err == nil {
 		t.Error("expected error")
 	}
 	transferRepo.Err = nil

--- a/internal/transfers/mock_transfer_repo.go
+++ b/internal/transfers/mock_transfer_repo.go
@@ -89,3 +89,10 @@ func (r *MockRepository) createUserTransfers(userID id.User, requests []*transfe
 func (r *MockRepository) deleteUserTransfer(id id.Transfer, userID id.User) error {
 	return r.Err
 }
+
+func (r *MockRepository) MarkTransfersAsProcessed(filename string, traceNumbers []string) (int64, error) {
+	if r.Err != nil {
+		return 0, r.Err
+	}
+	return 0, nil
+}

--- a/internal/transfers/repository_test.go
+++ b/internal/transfers/repository_test.go
@@ -233,3 +233,63 @@ func TestTransfers__SetReturnCode(t *testing.T) {
 	defer mysqlDB.Close()
 	check(t, mysqlDB.DB)
 }
+
+func TestTransfers__MarkTransfersAsProcessed(t *testing.T) {
+	t.Parallel()
+
+	check := func(t *testing.T, repo *SQLRepo) {
+		amt, _ := model.NewAmount("USD", "32.92")
+		userID := id.User(base.ID())
+		req := &transferRequest{
+			Type:                   model.PushTransfer,
+			Amount:                 *amt,
+			Originator:             model.OriginatorID("originator"),
+			OriginatorDepository:   id.Depository("originator"),
+			Receiver:               model.ReceiverID("receiver"),
+			ReceiverDepository:     id.Depository("receiver"),
+			Description:            "money",
+			StandardEntryClassCode: "PPD",
+			fileID:                 "test-file",
+		}
+		transfers, err := repo.createUserTransfers(userID, []*transferRequest{req})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(transfers) != 1 {
+			t.Fatalf("got transfers=%#v", transfers)
+		}
+
+		filename := "20200320-0000001.ach"
+		traceNumber := "000000987631"
+
+		// merge Transfer
+		if err := repo.MarkTransferAsMerged(transfers[0].ID, filename, traceNumber); err != nil {
+			t.Fatal(err)
+		}
+
+		// prep Transfer for upload
+		// include an extra traceNumber for sql query generator
+		if n, err := repo.MarkTransfersAsProcessed(filename, []string{traceNumber, "00032"}); n != 1 || err != nil {
+			t.Fatalf("n=%d error=%v", n, err)
+		}
+
+		// Check transfer status
+		xfer, err := repo.getUserTransfer(transfers[0].ID, userID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if xfer.Status != model.TransferProcessed {
+			t.Errorf("xfer.Status=%v", xfer.Status)
+		}
+	}
+
+	// SQLite tests
+	sqliteDB := database.CreateTestSqliteDB(t)
+	defer sqliteDB.Close()
+	check(t, NewTransferRepo(log.NewNopLogger(), sqliteDB.DB))
+
+	// MySQL tests
+	mysqlDB := database.CreateTestMySQLDB(t)
+	defer mysqlDB.Close()
+	check(t, NewTransferRepo(log.NewNopLogger(), mysqlDB.DB))
+}

--- a/internal/transfers/repository_test.go
+++ b/internal/transfers/repository_test.go
@@ -148,6 +148,9 @@ func TestTransfers__LookupTransferFromReturn(t *testing.T) {
 		if err := repo.MarkTransferAsMerged(transfers[0].ID, "merged.ach", "traceNumber"); err != nil {
 			t.Fatal(err)
 		}
+		if err := repo.UpdateTransferStatus(transfers[0].ID, model.TransferProcessed); err != nil {
+			t.Fatal(err)
+		}
 
 		// Now grab the transfer back
 		xfer, err := repo.LookupTransferFromReturn("PPD", amt, "traceNumber", time.Now()) // EffectiveEntryDate is bounded by start and end of a day


### PR DESCRIPTION
This PR changes PayGate to mark Transfer objects as `processed` only when they're to be uploaded. We do this because a Transfer can be deleted prior to the upload and 

Fixes: https://github.com/moov-io/paygate/issues/439