### PR TITLE
filetransfer: add admin endpoint for merging outgoing files

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -44,6 +44,7 @@ Class | Method | HTTP request | Description
 *AdminApi* | [**GetFeatures**](docs/AdminApi.md#getfeatures) | **Get** /features | Get an object of enabled features for this PayGate instance
 *AdminApi* | [**GetMicroDeposits**](docs/AdminApi.md#getmicrodeposits) | **Get** /depositories/{depositoryId}/micro-deposits | Get micro-deposits for a Depository
 *AdminApi* | [**GetVersion**](docs/AdminApi.md#getversion) | **Get** /version | Show the current version
+*AdminApi* | [**MergeFiles**](docs/AdminApi.md#mergefiles) | **Post** /files/merge | Merge transfers and micro-deposits into their outgoing ACH files
 *AdminApi* | [**UpdateCutoffTime**](docs/AdminApi.md#updatecutofftime) | **Put** /configs/filetransfers/cutoff-times/{routingNumber} | Update cutoff times for a given routing number
 *AdminApi* | [**UpdateDepositoryStatus**](docs/AdminApi.md#updatedepositorystatus) | **Put** /users/{userId}/depositories/{depositoryId} | Update Depository status
 *AdminApi* | [**UpdateFTPConfig**](docs/AdminApi.md#updateftpconfig) | **Put** /configs/filetransfers/ftp/{routingNumber} | Update FTP config for a given routing number

--- a/admin/api/openapi.yaml
+++ b/admin/api/openapi.yaml
@@ -396,6 +396,32 @@ paths:
       summary: Download and process all incoming and outgoing ACH files
       tags:
       - Admin
+  /files/merge:
+    post:
+      operationId: mergeFiles
+      parameters:
+      - description: Block HTTP response until all files are processed
+        explode: true
+        in: query
+        name: wait
+        required: true
+        schema:
+          example: true
+          type: boolean
+        style: form
+      responses:
+        200:
+          description: Transfers and micro-deposits are merged into their outgoing
+            files
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: See error message
+      summary: Merge transfers and micro-deposits into their outgoing ACH files
+      tags:
+      - Admin
   /users/{userId}/depositories/{depositoryId}:
     put:
       operationId: updateDepositoryStatus

--- a/admin/api_admin.go
+++ b/admin/api_admin.go
@@ -920,6 +920,81 @@ func (a *AdminApiService) GetVersion(ctx _context.Context) (string, *_nethttp.Re
 }
 
 /*
+MergeFiles Merge transfers and micro-deposits into their outgoing ACH files
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param wait Block HTTP response until all files are processed
+*/
+func (a *AdminApiService) MergeFiles(ctx _context.Context, wait bool) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodPost
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/files/merge"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	localVarQueryParams.Add("wait", parameterToString(wait, ""))
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
+/*
 UpdateCutoffTime Update cutoff times for a given routing number
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param routingNumber Routing Number

--- a/admin/docs/AdminApi.md
+++ b/admin/docs/AdminApi.md
@@ -15,6 +15,7 @@ Method | HTTP request | Description
 [**GetFeatures**](AdminApi.md#GetFeatures) | **Get** /features | Get an object of enabled features for this PayGate instance
 [**GetMicroDeposits**](AdminApi.md#GetMicroDeposits) | **Get** /depositories/{depositoryId}/micro-deposits | Get micro-deposits for a Depository
 [**GetVersion**](AdminApi.md#GetVersion) | **Get** /version | Show the current version
+[**MergeFiles**](AdminApi.md#MergeFiles) | **Post** /files/merge | Merge transfers and micro-deposits into their outgoing ACH files
 [**UpdateCutoffTime**](AdminApi.md#UpdateCutoffTime) | **Put** /configs/filetransfers/cutoff-times/{routingNumber} | Update cutoff times for a given routing number
 [**UpdateDepositoryStatus**](AdminApi.md#UpdateDepositoryStatus) | **Put** /users/{userId}/depositories/{depositoryId} | Update Depository status
 [**UpdateFTPConfig**](AdminApi.md#UpdateFTPConfig) | **Put** /configs/filetransfers/ftp/{routingNumber} | Update FTP config for a given routing number
@@ -358,6 +359,38 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: text/plain
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## MergeFiles
+
+> MergeFiles(ctx, wait)
+
+Merge transfers and micro-deposits into their outgoing ACH files
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**wait** | **bool**| Block HTTP response until all files are processed | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
 [[Back to Model list]](../README.md#documentation-for-models)

--- a/internal/filetransfer/controller.go
+++ b/internal/filetransfer/controller.go
@@ -208,6 +208,9 @@ type periodicFileOperationsRequest struct {
 	// userID is the x-user-id HTTP header
 	userID string
 
+	// skipUpload will signal to only merge transfers and micro-deposits
+	skipUpload bool
+
 	// waiter is an optional channel to signal when the file operations
 	// are completed. This is used to hold HTTP responses (for the admin
 	// endpoints).
@@ -262,7 +265,11 @@ func (c *Controller) StartPeriodicFileOperations(ctx context.Context, flushIncom
 			finish(req, &wg, errs)
 
 		case req := <-flushOutgoing:
-			c.logger.Log("StartPeriodicFileOperations", "flushing ACH files to their outbound destination", "requestID", req.requestID, "userID", req.userID)
+			if req.skipUpload {
+				c.logger.Log("StartPeriodicFileOperations", "merging ACH files to their outbound files", "requestID", req.requestID, "userID", req.userID)
+			} else {
+				c.logger.Log("StartPeriodicFileOperations", "flushing ACH files to their outbound destination", "requestID", req.requestID, "userID", req.userID)
+			}
 			if err := c.mergeAndUploadFiles(transferCursor, microDepositCursor, req, &mergeUploadOpts{force: true}); err != nil {
 				errs <- fmt.Errorf("mergeAndUploadFiles: %v", err)
 			}

--- a/internal/filetransfer/outgoing.go
+++ b/internal/filetransfer/outgoing.go
@@ -138,7 +138,11 @@ func (c *Controller) mergeAndUploadFiles(transferCur *transfers.Cursor, microDep
 	//
 	// FI's pay for each file that's uploaded, so it's important to merge and consolidate files to reduce their cost. ACH files have a maximum
 	// of 10k lines before needing to be split up.
-	c.logger.Log("file-transfer-controller", "Starting file merge and upload operations")
+	if req.skipUpload {
+		c.logger.Log("file-transfer-controller", "Starging ACH merge operations")
+	} else {
+		c.logger.Log("file-transfer-controller", "Starting file merge and upload operations")
+	}
 
 	var filesToUpload []*achFile // accumulator
 
@@ -173,6 +177,11 @@ func (c *Controller) mergeAndUploadFiles(transferCur *transfers.Cursor, microDep
 		if file := c.mergeMicroDeposit(microDeposits[i]); file != nil {
 			filesToUpload = append(filesToUpload, file)
 		}
+	}
+
+	// If the request asks us to only merge then skip the upload steps
+	if req.skipUpload {
+		return nil
 	}
 
 	// If we're being forced to upload everything then grab all files and upload them

--- a/openapi-admin.yaml
+++ b/openapi-admin.yaml
@@ -357,6 +357,28 @@ paths:
             application/json:
               schema:
                 $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+  /files/merge:
+    post:
+      tags: ["Admin"]
+      summary: Merge transfers and micro-deposits into their outgoing ACH files
+      operationId: mergeFiles
+      parameters:
+        - name: wait
+          in: query
+          description: Block HTTP response until all files are processed
+          required: true
+          schema:
+            type: boolean
+            example: true
+      responses:
+        '200':
+          description: Transfers and micro-deposits are merged into their outgoing files
+        '400':
+          description: See error message
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
   /users/{userId}/depositories/{depositoryId}:
     put:
       tags: ["Admin"]


### PR DESCRIPTION
This endpoint is only for merging files. It won't upload outgoing files.