### PR TITLE
route: mark non-200 response with x-user-id is missing

### DIFF
--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -57,6 +57,7 @@ type Responder struct {
 func NewResponder(logger log.Logger, w http.ResponseWriter, r *http.Request) *Responder {
 	writer, err := wrapResponseWriter(logger, w, r)
 	if err != nil {
+		moovhttp.Problem(w, err)
 		return nil
 	}
 	return &Responder{


### PR DESCRIPTION
When looking at https://github.com/moov-io/paygate/issues/465 I wanted to double check that requests without `x-user-id` return a non-200 status. 