### PR TITLE
database/mysql: expand transfers.amount column size

### DIFF
--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -161,6 +161,10 @@ var (
 			"removed_reclaimed_transfer_status",
 			`update transfers set status = 'failed' where status = 'reclaimed';`,
 		),
+		execsql(
+			"expand_transfers_amount",
+			`alter table transfers modify amount varchar(30);`,
+		),
 	)
 )
 

--- a/internal/transfers/limits.go
+++ b/internal/transfers/limits.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -166,16 +167,16 @@ func (lc *LimitChecker) userTransferSum(userID id.User, newerThan time.Time) (fl
 	}
 	defer stmt.Close()
 
-	var total *float64
+	var total *string
 	if err := stmt.QueryRow(userID, newerThan).Scan(&total); err != nil {
 		if err == sql.ErrNoRows {
-			fmt.Println("A")
 			return 0.0, nil
 		}
 		return -1.0, fmt.Errorf("user transfers query: %v", err)
 	}
 	if total != nil {
-		return *total, nil
+		f, _ := strconv.ParseFloat(*total, 64)
+		return f, nil
 	}
 	return 0.0, nil
 }

--- a/internal/transfers/limits_test.go
+++ b/internal/transfers/limits_test.go
@@ -83,7 +83,7 @@ func TestLimits__overLimit(t *testing.T) {
 func TestLimits__integration(t *testing.T) {
 	t.Parallel()
 
-	limits, err := ParseLimits("100.00", "100.00", "250.00")
+	limits, err := ParseLimits("1000.00", "1000.00", "2500.00")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestLimits__integration(t *testing.T) {
 		}
 
 		// write a transfer
-		amt, _ := model.NewAmount("USD", "25.12")
+		amt, _ := model.NewAmount("USD", "250.12")
 		xferReq := []*transferRequest{
 			{
 				Type:                   model.PushTransfer,
@@ -126,7 +126,7 @@ func TestLimits__integration(t *testing.T) {
 		}
 
 		// write another transfer
-		amt, _ = model.NewAmount("USD", "121.44")
+		amt, _ = model.NewAmount("USD", "1213.44")
 		xferReq[0].Amount = *amt
 		if _, err := repo.createUserTransfers(userID, xferReq); err != nil {
 			t.Fatal(err)
@@ -139,8 +139,10 @@ func TestLimits__integration(t *testing.T) {
 		if total, err := lc.userTransferSum(userID, time.Now().Add(-24*time.Hour)); err != nil {
 			t.Fatal(err)
 		} else {
-			if int(total*100) != 2512+12144 {
-				t.Errorf("got %.2f", total)
+			got := int(total * 100)
+			expected := 25012 + 121344
+			if got != expected {
+				t.Errorf("got %d expected %d", got, expected)
 			}
 		}
 	}


### PR DESCRIPTION
Found this bug with MySQL where amounts are stored in too small of a column. 