### PR TITLE
all: split 'err and object nil' checks into two blocks

### DIFF
--- a/internal/originators/originators.go
+++ b/internal/originators/originators.go
@@ -120,9 +120,13 @@ func createUserOriginator(logger log.Logger, accountsClient accounts.Client, cus
 		// Verify account exists in Accounts for receiver (userID)
 		if accountsClient != nil {
 			account, err := accountsClient.SearchAccounts(requestID, userID, dep)
-			if err != nil || account == nil {
+			if err != nil {
 				responder.Log("originators", fmt.Sprintf("problem finding account depository=%s: %v", dep.ID, err))
 				responder.Problem(err)
+				return
+			}
+			if account == nil {
+				responder.Problem(errors.New("account not found"))
 				return
 			}
 		}
@@ -140,9 +144,13 @@ func createUserOriginator(logger log.Logger, accountsClient accounts.Client, cus
 				opts.BirthDate = *req.BirthDate
 			}
 			customer, err := customersClient.Create(opts)
-			if err != nil || customer == nil {
+			if err != nil {
 				responder.Log("originators", "error creating Customer", "error", err)
 				responder.Problem(err)
+				return
+			}
+			if customer == nil {
+				responder.Problem(errors.New("customer not found"))
 				return
 			}
 			responder.Log("originators", fmt.Sprintf("created customer=%s", customer.ID))

--- a/internal/originators/originators_test.go
+++ b/internal/originators/originators_test.go
@@ -100,7 +100,12 @@ func TestOriginators_CustomersError(t *testing.T) {
 		},
 	}
 
-	customersClient := &customers.TestClient{}
+	customersClient := &customers.TestClient{
+		Customer: &customers.Customer{
+			ID:     base.ID(),
+			Status: "ofac",
+		},
+	}
 	createUserOriginator(logger, accountsClient, customersClient, depRepo, origRepo)(w, req)
 	w.Flush()
 

--- a/internal/receivers/receivers.go
+++ b/internal/receivers/receivers.go
@@ -147,9 +147,13 @@ func createUserReceiver(logger log.Logger, customersClient customers.Client, dep
 				opts.BirthDate = *req.BirthDate
 			}
 			customer, err := customersClient.Create(opts)
-			if err != nil || customer == nil {
+			if err != nil {
 				responder.Log("receivers", "error creating customer", "error", err)
 				responder.Problem(err)
+				return
+			}
+			if customer == nil {
+				responder.Problem(errors.New("customer not found"))
 				return
 			}
 			responder.Log("receivers", fmt.Sprintf("created customer=%s", customer.ID))

--- a/internal/transfers/transfers.go
+++ b/internal/transfers/transfers.go
@@ -324,8 +324,12 @@ func (c *TransferRouter) createUserTransfers() http.HandlerFunc {
 		remoteIP := route.RemoteAddr(r.Header)
 
 		gateway, err := c.gatewayRepo.GetUserGateway(responder.XUserID)
-		if gateway == nil || err != nil {
+		if err != nil {
 			responder.Problem(fmt.Errorf("missing Gateway: %v", err))
+			return
+		}
+		if gateway == nil {
+			responder.Problem(errors.New("gateway not found"))
 			return
 		}
 


### PR DESCRIPTION
This error shows itself as returning "200 OK" in HTTP routes when
there's an underlying error. The error is logged, but the route does
not return an error.

The way this works is we call moovhttp.Prolbem(nil) which skips over
setting the status code to http.StatusBadRequest and any error
marshaling. Then the http.ResponseWriter will assume "200 OK" when the
response finishes.