### PR TITLE
transfers/pipeline/notify: setup a basic email template

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -59,5 +59,5 @@ pipeline:
  #     topic: ''
   notifications:
     email:
-      connection_uri: "smtps://test:test@localhost:1025/?skip_ssl_verify=true"
+      connection_uri: "smtps://test:test@localhost:1025/?insecure_skip_verify=true"
       company_name: "Moov"

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/moov-io/ofac v0.12.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/ory/dockertest/v3 v3.6.0
+	github.com/ory/mail/v3 v3.0.0
 	github.com/pkg/sftp v1.11.0
 	github.com/prometheus/client_golang v1.6.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -446,6 +446,10 @@ github.com/ory/dockertest/v3 v3.5.2/go.mod h1:vp8R9lFWwhRy6FmDW1c0/OKcbgq36GDatp
 github.com/ory/dockertest/v3 v3.5.4/go.mod h1:J8ZUbNB2FOhm1cFZW9xBpDsODqsSWcyYgtJYVPcnF70=
 github.com/ory/dockertest/v3 v3.6.0 h1:I6KNJ6izxGduLACQii2SP/g7GN0JM9Xfaik6aAVaw6Y=
 github.com/ory/dockertest/v3 v3.6.0/go.mod h1:4ZOpj8qBUmh8fcBSVzkH2bws2s91JdGvHUqan4GHEuQ=
+github.com/ory/mail v2.3.1+incompatible h1:vHntHDHtQXamt2T+iwTTlCoBkDvILUeujE9Ocwe9md4=
+github.com/ory/mail v2.3.1+incompatible/go.mod h1:87D9/1gB6ewElQoN0lXJ0ayfqcj3cW3qCTXh+5E9mfU=
+github.com/ory/mail/v3 v3.0.0 h1:8LFMRj473vGahFD/ntiotWEd4S80FKYFtiZTDfOQ+sM=
+github.com/ory/mail/v3 v3.0.0/go.mod h1:JGAVeZF8YAlxbaFDUHqRZAKBCSeW2w1vuxf28hFbZAw=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pariz/gountries v0.0.0-20191029140926-233bc78cf5b5/go.mod h1:U0ETmPPEsfd7CpUKNMYi68xIOL8Ww4jPZlaqNngcwqs=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -797,6 +801,7 @@ google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zim
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -816,6 +821,7 @@ gopkg.in/jcmturner/gokrb5.v7 v7.5.0 h1:a9tsXlIDD9SKxotJMK3niV7rPZAJeX2aD/0yg3qlI
 gopkg.in/jcmturner/gokrb5.v7 v7.5.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0 h1:QHIUxTX1ISuAv9dD2wJ9HWQVuWDX/Zc0PfeC2tjc4rU=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
+gopkg.in/mail.v2 v2.3.1/go.mod h1:htwXN1Qh09vZJ1NVKxQqHPBaCBbzKhp5GzuJEA4VJWw=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -51,11 +51,11 @@ type PipelineNotifications struct {
 }
 
 type Email struct {
-	// TODO(adam): sftp creds
-	To       string `yaml:"to"`
-	Template string `yaml:"template"`
-
-	CompanyName string `yaml:"company_name"` // e.g. Moov
+	From          string   `yaml:"from"`
+	To            []string `yaml:"to"`
+	ConnectionURI string   `yaml:"connection_uri"`
+	Template      string   `yaml:"template"`
+	CompanyName   string   `yaml:"company_name"` // e.g. Moov
 }
 
 func (e *Email) Tmpl() *template.Template {

--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -11,8 +11,8 @@ import (
 var (
 	DefaultEmailTemplate = template.Must(template.New("email").Parse(`
 A file has been {{ .Verb }}ed from {{ .CompanyName }}: {{ .Filename }}
-Debits:  {{ .DebitTotal }}
-Credits: {{ .CreditTotal }}
+Debits:  ${{ .DebitTotal | printf "%.2f" }}
+Credits: ${{ .CreditTotal | printf "%.2f" }}
 
 Batches: {{ .BatchCount }}
 Total Entries: {{ .EntryCount }}

--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -51,11 +51,19 @@ type PipelineNotifications struct {
 }
 
 type Email struct {
-	From          string   `yaml:"from"`
-	To            []string `yaml:"to"`
-	ConnectionURI string   `yaml:"connection_uri"`
-	Template      string   `yaml:"template"`
-	CompanyName   string   `yaml:"company_name"` // e.g. Moov
+	From string   `yaml:"from"`
+	To   []string `yaml:"to"`
+
+	// ConnectionURI is a URI used to connect with a remote SFTP server.
+	// This config typically needs to contain enough values to successfully
+	// authenticate with the server.
+	// - insecure_skip_verify is an optional parameter for disabling certificate verification
+	//
+	// Example: smtps://user:pass@localhost:1025/?insecure_skip_verify=true
+	ConnectionURI string `yaml:"connection_uri"`
+
+	Template    string `yaml:"template"`
+	CompanyName string `yaml:"company_name"` // e.g. Moov
 }
 
 func (e *Email) Tmpl() *template.Template {

--- a/pkg/transfers/pipeline/aggregate.go
+++ b/pkg/transfers/pipeline/aggregate.go
@@ -158,24 +158,22 @@ func (xfagg *XferAggregator) uploadFile(f *ach.File) error {
 	})
 
 	// Send Slack/PD or whatever notifications after the file is uploaded
-	xfagg.notifyAfterUpload(filename, err)
+	xfagg.notifyAfterUpload(filename, f, err)
 
 	return err
 }
 
-func (xfagg *XferAggregator) notifyAfterUpload(filename string, err error) {
-	body := fmt.Sprintf("upload of %s", filename)
+func (xfagg *XferAggregator) notifyAfterUpload(filename string, file *ach.File, err error) {
+	msg := &notify.Message{
+		Direction: notify.Upload,
+		Filename:  filename,
+		File:      file,
+	}
 	if err != nil {
-		msg := &notify.Message{
-			Body: "failed to " + body,
-		}
 		if err := xfagg.notifier.Critical(msg); err != nil {
 			xfagg.logger.Log("problem sending critical notification for file=%s: %v", filename, err)
 		}
 	} else {
-		msg := &notify.Message{
-			Body: "successful " + body,
-		}
 		if err := xfagg.notifier.Info(msg); err != nil {
 			xfagg.logger.Log("problem sending info notification for file=%s: %v", filename, err)
 		}

--- a/pkg/transfers/pipeline/notify/email.go
+++ b/pkg/transfers/pipeline/notify/email.go
@@ -1,0 +1,88 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/paygate/pkg/config"
+)
+
+type Email struct {
+	// smtp client
+	cfg *config.Email
+}
+
+type EmailTemplateData struct {
+	CompanyName string // e.g. Moov
+	Verb        string // e.g. uploaded, downloaded
+	Filename    string // e.g. 20200529-131400.ach
+
+	DebitTotal  int
+	CreditTotal int
+
+	BatchCount int
+	EntryCount int
+}
+
+var (
+	// Ensure the default template validates against our data struct
+	_ = config.DefaultEmailTemplate.Execute(ioutil.Discard, EmailTemplateData{})
+)
+
+func NewEmail(cfg *config.Email) (*Email, error) {
+	return &Email{
+		cfg: cfg,
+	}, nil
+}
+
+// use msg.File and msg.Filename with template to marshal email contents
+
+func (mailer *Email) Info(msg *Message) error {
+	contents, err := marshalEmail(mailer.cfg, msg)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("[INFO] email: contents=%s", contents)
+	return nil
+}
+
+func (mailer *Email) Critical(msg *Message) error {
+	fmt.Printf("[CRITICAL] email: message=%#v", msg)
+	return nil
+}
+
+func marshalEmail(cfg *config.Email, msg *Message) (string, error) {
+	data := EmailTemplateData{
+		CompanyName: cfg.CompanyName,
+		Verb:        string(msg.Direction),
+		Filename:    msg.Filename,
+		DebitTotal:  msg.File.Control.TotalDebitEntryDollarAmountInFile,
+		CreditTotal: msg.File.Control.TotalCreditEntryDollarAmountInFile,
+		BatchCount:  msg.File.Control.BatchCount,
+		EntryCount:  countEntries(msg.File),
+	}
+
+	var buf bytes.Buffer
+	if err := cfg.Tmpl().Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func sendEmail() error {
+	return nil
+}
+
+func countEntries(file *ach.File) int {
+	var total int
+	for i := range file.Batches {
+		total += len(file.Batches[i].GetEntries())
+	}
+	return total
+}

--- a/pkg/transfers/pipeline/notify/email.go
+++ b/pkg/transfers/pipeline/notify/email.go
@@ -28,7 +28,7 @@ type Email struct {
 
 type EmailTemplateData struct {
 	CompanyName string // e.g. Moov
-	Verb        string // e.g. uploaded, downloaded
+	Verb        string // e.g. upload, download
 	Filename    string // e.g. 20200529-131400.ach
 
 	DebitTotal  float64
@@ -66,8 +66,8 @@ func setupGoMailClient(cfg *config.Email) (*gomail.Dialer, error) {
 
 	ssl := strings.EqualFold(uri.Scheme, "smtps")
 	if ssl {
-		sslSkipVerify, _ := strconv.ParseBool(uri.Query().Get("skip_ssl_verify"))
-		tlsConfig = &tls.Config{InsecureSkipVerify: sslSkipVerify}
+		skipVerify, _ := strconv.ParseBool(uri.Query().Get("insecure_skip_verify"))
+		tlsConfig = &tls.Config{InsecureSkipVerify: skipVerify}
 	}
 
 	return &gomail.Dialer{
@@ -128,8 +128,6 @@ func sendEmail(cfg *config.Email, dialer *gomail.Dialer, filename, body string) 
 	m.SetBody("text/plain", body)
 
 	if err := dialer.DialAndSend(context.Background(), m); err != nil {
-		fmt.Printf("m=%#v\n", m)
-		fmt.Printf("dialer=%#v\n", dialer)
 		return err
 	}
 	return nil

--- a/pkg/transfers/pipeline/notify/email.go
+++ b/pkg/transfers/pipeline/notify/email.go
@@ -31,8 +31,8 @@ type EmailTemplateData struct {
 	Verb        string // e.g. uploaded, downloaded
 	Filename    string // e.g. 20200529-131400.ach
 
-	DebitTotal  int
-	CreditTotal int
+	DebitTotal  float64
+	CreditTotal float64
 
 	BatchCount int
 	EntryCount int
@@ -103,8 +103,8 @@ func marshalEmail(cfg *config.Email, msg *Message) (string, error) {
 		CompanyName: cfg.CompanyName,
 		Verb:        string(msg.Direction),
 		Filename:    msg.Filename,
-		DebitTotal:  msg.File.Control.TotalDebitEntryDollarAmountInFile,
-		CreditTotal: msg.File.Control.TotalCreditEntryDollarAmountInFile,
+		DebitTotal:  convertDollar(msg.File.Control.TotalDebitEntryDollarAmountInFile),
+		CreditTotal: convertDollar(msg.File.Control.TotalCreditEntryDollarAmountInFile),
 		BatchCount:  msg.File.Control.BatchCount,
 		EntryCount:  countEntries(msg.File),
 	}
@@ -114,6 +114,10 @@ func marshalEmail(cfg *config.Email, msg *Message) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func convertDollar(in int) float64 {
+	return float64(in) / 100.0
 }
 
 func sendEmail(cfg *config.Email, dialer *gomail.Dialer, filename, body string) error {

--- a/pkg/transfers/pipeline/notify/email_test.go
+++ b/pkg/transfers/pipeline/notify/email_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/paygate/pkg/config"
+)
+
+func TestEmail__marshal(t *testing.T) {
+	cfg := &config.Email{
+		CompanyName: "Moov",
+	}
+	msg := &Message{
+		Direction: Upload,
+		Filename:  "20200529-131400.ach",
+	}
+	if f, err := ach.ReadFile(filepath.Join("..", "..", "..", "..", "testdata", "ppd-debit.ach")); err != nil {
+		t.Fatal(err)
+	} else {
+		msg.File = f
+	}
+
+	contents, err := marshalEmail(cfg, msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if testing.Verbose() {
+		t.Log(contents)
+	}
+
+	if !strings.Contains(contents, `A file has been uploaded from Moov: 20200529-131400.ach`) {
+		t.Error("generated template doesn't match")
+	}
+	if !strings.Contains(contents, `Debits:  10500`) {
+		t.Error("generated template doesn't match")
+	}
+	if !strings.Contains(contents, `Credits: 0`) {
+		t.Error("generated template doesn't match")
+	}
+	if !strings.Contains(contents, `Batches: 1`) {
+		t.Error("generated template doesn't match")
+	}
+	if !strings.Contains(contents, `Total Entries: 1`) {
+		t.Error("generated template doesn't match")
+	}
+}

--- a/pkg/transfers/pipeline/notify/email_test.go
+++ b/pkg/transfers/pipeline/notify/email_test.go
@@ -75,10 +75,10 @@ func TestEmail__marshal(t *testing.T) {
 	if !strings.Contains(contents, `A file has been uploaded from Moov: 20200529-131400.ach`) {
 		t.Error("generated template doesn't match")
 	}
-	if !strings.Contains(contents, `Debits:  10500`) {
+	if !strings.Contains(contents, `Debits:  $105.00`) {
 		t.Error("generated template doesn't match")
 	}
-	if !strings.Contains(contents, `Credits: 0`) {
+	if !strings.Contains(contents, `Credits: $0.00`) {
 		t.Error("generated template doesn't match")
 	}
 	if !strings.Contains(contents, `Batches: 1`) {

--- a/pkg/transfers/pipeline/notify/email_test.go
+++ b/pkg/transfers/pipeline/notify/email_test.go
@@ -22,7 +22,7 @@ func TestEmailSend(t *testing.T) {
 		To: []string{
 			"jane@company.com",
 		},
-		ConnectionURI: fmt.Sprintf("smtps://test:test@localhost:%s/?skip_ssl_verify=true", dep.SMTPPort()),
+		ConnectionURI: fmt.Sprintf("smtps://test:test@localhost:%s/?insecure_skip_verify=true", dep.SMTPPort()),
 		CompanyName:   "Moov",
 	}
 

--- a/pkg/transfers/pipeline/notify/mailslurper_test.go
+++ b/pkg/transfers/pipeline/notify/mailslurper_test.go
@@ -1,0 +1,67 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/moov-io/base/docker"
+
+	"github.com/ory/dockertest/v3"
+)
+
+type mailslurpDeployment struct {
+	container *dockertest.Resource
+}
+
+func (dep *mailslurpDeployment) SMTPPort() string {
+	return dep.container.GetPort("1025/tcp")
+}
+
+func (dep *mailslurpDeployment) Close() error {
+	return dep.container.Close()
+}
+
+func spawnMailslurp(t *testing.T) *mailslurpDeployment {
+	if testing.Short() || !docker.Enabled() {
+		t.Skip("skipping docker test")
+	}
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	container, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository:   "oryd/mailslurper",
+		Tag:          "latest-smtps",
+		ExposedPorts: []string{"1025"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dep := &mailslurpDeployment{
+		container: container,
+	}
+
+	err = pool.Retry(func() error {
+		time.Sleep(1 * time.Second)
+
+		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%s", dep.SMTPPort()))
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return dep
+}

--- a/pkg/transfers/pipeline/notify/multi.go
+++ b/pkg/transfers/pipeline/notify/multi.go
@@ -19,8 +19,8 @@ func NewMultiSender(cfg *config.PipelineNotifications) (*MultiSender, error) {
 	if cfg == nil {
 		return ms, nil
 	}
-	if cfg.Slack != nil {
-		sender, err := NewSlack(cfg.Slack)
+	if cfg.Email != nil {
+		sender, err := NewEmail(cfg.Email)
 		if err != nil {
 			return nil, err
 		}
@@ -28,6 +28,13 @@ func NewMultiSender(cfg *config.PipelineNotifications) (*MultiSender, error) {
 	}
 	if cfg.PagerDuty != nil {
 		sender, err := NewPagerDuty(cfg.PagerDuty)
+		if err != nil {
+			return nil, err
+		}
+		ms.senders = append(ms.senders, sender)
+	}
+	if cfg.Slack != nil {
+		sender, err := NewSlack(cfg.Slack)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/transfers/pipeline/notify/notify.go
+++ b/pkg/transfers/pipeline/notify/notify.go
@@ -4,8 +4,21 @@
 
 package notify
 
+import (
+	"github.com/moov-io/ach"
+)
+
+type Direction string
+
+const (
+	Upload   Direction = "upload"
+	Download Direction = "download"
+)
+
 type Message struct {
-	Body string
+	Direction Direction
+	Filename  string
+	File      *ach.File
 }
 
 type Sender interface {

--- a/pkg/transfers/pipeline/notify/pagerduty.go
+++ b/pkg/transfers/pipeline/notify/pagerduty.go
@@ -19,11 +19,17 @@ func NewPagerDuty(cfg *config.PagerDuty) (*PagerDuty, error) {
 }
 
 func (pd *PagerDuty) Info(msg *Message) error {
-	fmt.Printf("[INFO] pagerduty: message=%#v", msg)
+	body := "successful " + pagerdutyMessage(msg)
+	fmt.Printf("[INFO] pagerduty: body=%q\n", body)
 	return nil
 }
 
 func (pd *PagerDuty) Critical(msg *Message) error {
-	fmt.Printf("[CRITICAL] pagerduty: message=%#v", msg)
+	body := "failed to " + pagerdutyMessage(msg)
+	fmt.Printf("[CRITICAL] pagerduty: body=%q\n", body)
 	return nil
+}
+
+func pagerdutyMessage(msg *Message) string {
+	return fmt.Sprintf("%s of %s", msg.Direction, msg.Filename)
 }

--- a/pkg/transfers/pipeline/notify/pagerduty_test.go
+++ b/pkg/transfers/pipeline/notify/pagerduty_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"testing"
+
+	"github.com/moov-io/paygate/pkg/config"
+)
+
+func TestPagerDuty(t *testing.T) {
+	pd, err := NewPagerDuty(&config.PagerDuty{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := &Message{
+		Direction: Download,
+		Filename:  "20200529-140002.ach",
+	}
+
+	if err := pd.Info(msg); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pd.Critical(msg); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/transfers/pipeline/notify/slack.go
+++ b/pkg/transfers/pipeline/notify/slack.go
@@ -19,11 +19,17 @@ func NewSlack(cfg *config.Slack) (*Slack, error) {
 }
 
 func (s *Slack) Info(msg *Message) error {
-	fmt.Printf("[INFO] slack: message=%#v", msg)
+	body := "successful " + slackMessage(msg)
+	fmt.Printf("[INFO] slack: body=%q\n", body)
 	return nil
 }
 
 func (s *Slack) Critical(msg *Message) error {
-	fmt.Printf("[CRITICAL] slack: message=%#v", msg)
+	body := "failed to " + slackMessage(msg)
+	fmt.Printf("[CRITICAL] slack: body=%q\n", body)
 	return nil
+}
+
+func slackMessage(msg *Message) string {
+	return fmt.Sprintf("%s of %s", msg.Direction, msg.Filename)
 }

--- a/pkg/transfers/pipeline/notify/slack_test.go
+++ b/pkg/transfers/pipeline/notify/slack_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package notify
+
+import (
+	"testing"
+
+	"github.com/moov-io/paygate/pkg/config"
+)
+
+func TestSlack(t *testing.T) {
+	slack, err := NewSlack(&config.Slack{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := &Message{
+		Direction: Download,
+		Filename:  "20200529-152259.ach",
+	}
+
+	if err := slack.Info(msg); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := slack.Critical(msg); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This will be used to send automated emails after an ACH file is uploaded or when an error occurs during upload.