### PR TITLE
upload: setup FTP and SFTP tests for a directory inside inbound/returns

### DIFF
--- a/pkg/upload/ftp_test.go
+++ b/pkg/upload/ftp_test.go
@@ -347,7 +347,7 @@ func TestFTP__Issue494(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if len(files) != 0 {
+	if len(files) != 1 {
 		t.Errorf("got %d files: %v", len(files), files)
 	}
 }

--- a/pkg/upload/ftp_test.go
+++ b/pkg/upload/ftp_test.go
@@ -29,6 +29,8 @@ import (
 
 var (
 	portSource = rand.NewSource(time.Now().Unix())
+
+	rootFTPPath = filepath.Join("..", "..", "testdata", "ftp-server")
 )
 
 func port() int {
@@ -41,9 +43,8 @@ func createTestFTPServer(t *testing.T) (*server.Server, error) {
 		t.Skip("skipping due to -short")
 	}
 
-	rootPath := filepath.Join("..", "..", "testdata", "ftp-server")
 	// Create the outbound directory, this seems especially flakey in remote CI
-	if err := os.MkdirAll(filepath.Join(rootPath, "outbound"), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Join(rootFTPPath, "outbound"), 0777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -53,7 +54,7 @@ func createTestFTPServer(t *testing.T) (*server.Server, error) {
 			Password: "password",
 		},
 		Factory: &filedriver.FileDriverFactory{
-			RootPath: rootPath,
+			RootPath: rootFTPPath,
 			Perm:     server.NewSimplePerm("test", "test"),
 		},
 		Hostname: "localhost",
@@ -290,7 +291,7 @@ func TestFTP__uploadFile(t *testing.T) {
 	}
 
 	// Create outbound directory
-	parent := filepath.Join("..", "..", "..", "testdata", "ftp-server", agent.OutboundPath())
+	parent := filepath.Join(rootFTPPath, agent.OutboundPath())
 	if err := os.MkdirAll(parent, 0777); err != nil {
 		t.Fatal(err)
 	}
@@ -323,5 +324,30 @@ func TestFTP__uploadFile(t *testing.T) {
 	agent.cfg.FTP = nil
 	if err := agent.UploadFile(f); err == nil {
 		t.Error("expected error")
+	}
+}
+
+func TestFTP__Issue494(t *testing.T) {
+	// Issue 494 talks about how readFiles fails when directories exist inside of
+	// the return/inbound directories. Let's make a directory inside and verify
+	// downloads happen.
+	svc, agent := createTestFTPAgent(t)
+	defer agent.Close()
+	defer svc.Shutdown()
+
+	// Create extra directory
+	path := filepath.Join(rootFTPPath, agent.ReturnPath(), "issue494")
+	if err := os.MkdirAll(path, 0777); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+
+	// Read without an error
+	files, err := agent.GetReturnFiles()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(files) != 0 {
+		t.Errorf("got %d files: %v", len(files), files)
 	}
 }

--- a/pkg/upload/sftp.go
+++ b/pkg/upload/sftp.go
@@ -329,6 +329,17 @@ func (agent *SFTPTransferAgent) readFiles(dir string) ([]File, error) {
 		if err != nil {
 			return nil, fmt.Errorf("sftp: open %s: %v", infos[i].Name(), err)
 		}
+
+		// skip this file descriptor if it's a directory - we only reading one level deep
+		info, err := fd.Stat()
+		if err != nil {
+			return nil, fmt.Errorf("sftp: stat %s: %v", infos[i].Name(), err)
+		}
+		if info.IsDir() {
+			continue
+		}
+
+		// download the remote file to our local directory
 		var buf bytes.Buffer
 		if n, err := io.Copy(&buf, fd); n == 0 || err != nil {
 			fd.Close()


### PR DESCRIPTION
It turns out we were encountering directories and downloading them as zero-length files, but assuming they were files. 

Fixes: https://github.com/moov-io/paygate/issues/494 