### PR TITLE
transfers/pipeline: add an audit trail storage interface

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -140,6 +140,16 @@ pipeline:
     [ format: <string> | default = "nacha" ]
   merging:
     [ directory: <filename> ]
+  audit_trail:
+    # BucketURI is a URI used to connect to a remote storage layer for saving
+    # ACH files uploaded to the ODFI as part of records retention.
+    # See the provider docs for more information: https://gocloud.dev/howto/blob/
+    #
+    # Example: gs://my-bucket
+    bucket_uri: <string>
+    gpg:
+      # Optional filepath used for encrypting ACH files when they're saved for auditing
+      [ key_file: <filename> ]
   stream:
     inmem:
       [ url: <address> ]

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/Azure/azure-amqp-common-go v1.1.4/go.mod h1:FhZtXirFANw40UXI2ntweO+VO
 github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuEd+YuKoUiazDC/N96FiDEU=
 github.com/Azure/azure-pipeline-go v0.1.8/go.mod h1:XA1kFWRVhSK+KNFiOhfv83Fv8L9achrP7OxIzeTn1Yg=
 github.com/Azure/azure-pipeline-go v0.1.9/go.mod h1:XA1kFWRVhSK+KNFiOhfv83Fv8L9achrP7OxIzeTn1Yg=
+github.com/Azure/azure-pipeline-go v0.2.1 h1:OLBdZJ3yvOn2MezlWvbrBMTEUQC72zAftRZOMdj5HYo=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-sdk-for-go v21.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v27.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -30,6 +31,7 @@ github.com/Azure/azure-sdk-for-go v30.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/azure-service-bus-go v0.4.1/go.mod h1:d9ho9e/06euiTwGpKxmlbpPhFUsfCsq6a4tZ68r51qI=
 github.com/Azure/azure-service-bus-go v0.9.1/go.mod h1:yzBx6/BUGfjfeqbRZny9AQIbIe3AcV9WZbAdpkoXOa0=
 github.com/Azure/azure-storage-blob-go v0.6.0/go.mod h1:oGfmITT1V6x//CswqY2gtAHND+xIP64/qL7a5QJix0Y=
+github.com/Azure/azure-storage-blob-go v0.8.0 h1:53qhf0Oxa0nOjgbDeeYPUeyiNmafAFEY95rZLK0Tj6o=
 github.com/Azure/azure-storage-blob-go v0.8.0/go.mod h1:lPI3aLPpuLTeUwh1sViKXFxwl2B6teiRqI0deQUvsw0=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -79,6 +81,7 @@ github.com/aws/aws-sdk-go v1.19.45/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.29.1/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/aws/aws-sdk-go v1.30.24/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.31.0 h1:ITLZ0oy7IOB1NGt2Ee75bLevBaH1jaAXE2eyGbPRbCg=
 github.com/aws/aws-sdk-go v1.31.0/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/bbalet/stopwords v1.0.0/go.mod h1:sAWrQoDMfqARGIn4s6dp7OW7ISrshUD8IP2q3KoqPjc=
@@ -213,6 +216,7 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.2.2/go.mod h1:7FHVg6mFpFQrjeUZrm+BaD50N5jnDKm50uVPTpyYOmU=
 github.com/google/wire v0.3.0 h1:imGQZGEVEHpje5056+K+cgdO72p0LQv2xIIFXNGUf60=
@@ -304,6 +308,7 @@ github.com/jlaffaye/ftp v0.0.0-20200422224957-b9f3ade29122 h1:dzYWuozdWNaY7mTQh5
 github.com/jlaffaye/ftp v0.0.0-20200422224957-b9f3ade29122/go.mod h1:PwUeyujmhaGohgOf0kJKxPfk3HcRv8QD/wAUN44go4k=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -343,6 +348,7 @@ github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0Q
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149 h1:HfxbT6/JcvIljmERptWhwa8XzP7H3T+Z2N26gTsaDaA=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -604,6 +610,7 @@ gocloud.dev v0.15.0/go.mod h1:ShXCyJaGrJu9y/7a6+DSCyBb9MFGZ1P5wwPa0Wu6w34=
 gocloud.dev v0.17.0/go.mod h1:tIHTRdR1V5dlD8sTkzYdTGizBJ314BDykJ8KmadEXwo=
 gocloud.dev v0.19.0 h1:EDRyaRAnMGSq/QBto486gWFxMLczAfIYUmusV7XLNBM=
 gocloud.dev v0.19.0/go.mod h1:SmKwiR8YwIMMJvQBKLsC3fHNyMwXLw3PMDO+VVteJMI=
+gocloud.dev v0.20.0 h1:mbEKMfnyPV7W1Rj35R1xXfjszs9dXkwSOq2KoFr25g8=
 gocloud.dev/pubsub/kafkapubsub v0.19.0 h1:rB2T/u7gU6GqAkwLmU/xnK3jNc/ZV9snYGIdCmoe21w=
 gocloud.dev/pubsub/kafkapubsub v0.19.0/go.mod h1:tQgteR3gnYFlcU5riE/96KZkbB5UXUL6AweVJNJiW4k=
 gocloud.dev/secrets/hashivault v0.19.0 h1:WU1m8spYGDS0SAo1URKQukoURtu60ecj1+4qhL7BIIE=

--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -25,6 +25,7 @@ type Pipeline struct {
 	PreUpload     *PreUpload             `yaml:"pre_upload" json:"pre_upload"`
 	Output        *Output                `yaml:"output" json:"output"`
 	Merging       *Merging               `yaml:"merging" json:"merging"`
+	AuditTrail    *AuditTrail            `yaml:"audit_trail" json:"audit_trail"`
 	Stream        *StreamPipeline        `yaml:"stream" json:"stream"`
 	Notifications *PipelineNotifications `yaml:"notifications" json:"notifications"`
 }
@@ -38,6 +39,9 @@ func (cfg Pipeline) Validate() error {
 	}
 	if err := cfg.Merging.Validate(); err != nil {
 		return fmt.Errorf("merging: %v", err)
+	}
+	if err := cfg.AuditTrail.Validate(); err != nil {
+		return fmt.Errorf("audit-trail: %v", err)
 	}
 	if err := cfg.Stream.Validate(); err != nil {
 		return fmt.Errorf("stream: %v", err)
@@ -79,6 +83,21 @@ type Merging struct {
 }
 
 func (cfg *Merging) Validate() error {
+	return nil
+}
+
+type AuditTrail struct {
+	BucketURI string `yaml:"bucket_uri" json:"bucket_uri"`
+	GPG       *GPG   `yaml:"gpg" json:"gpg"`
+}
+
+func (cfg *AuditTrail) Validate() error {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.BucketURI == "" {
+		return errors.New("missing bucket_uri")
+	}
 	return nil
 }
 

--- a/pkg/config/pipeline_test.go
+++ b/pkg/config/pipeline_test.go
@@ -26,6 +26,13 @@ func TestPreupload(t *testing.T) {
 	}
 }
 
+func TestAuditTrail(t *testing.T) {
+	cfg := &AuditTrail{}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error")
+	}
+}
+
 func TestStreamPipeline(t *testing.T) {
 	cfg := &StreamPipeline{
 		InMem: &InMemPipeline{

--- a/pkg/transfers/pipeline/audittrail/storage.go
+++ b/pkg/transfers/pipeline/audittrail/storage.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package audittrail
+
+import (
+	"errors"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/paygate/pkg/config"
+)
+
+// Storage is an interface for saving and encrypting ACH files for
+// records retention. This is often a requirement of agreements.
+//
+// File retention after upload is not part of this storage.
+type Storage interface {
+	// SaveFile will encrypt and copy the ACH file to the configured file storage.
+	SaveFile(filename string, file *ach.File) error
+
+	Close() error
+}
+
+func NewStorage(cfg *config.AuditTrail) (Storage, error) {
+	if cfg == nil {
+		return &MockStorage{}, nil
+	}
+	if cfg.BucketURI != "" {
+		return newBlobStorage(cfg)
+	}
+	return nil, errors.New("unknown storage config")
+}

--- a/pkg/transfers/pipeline/audittrail/storage_blob.go
+++ b/pkg/transfers/pipeline/audittrail/storage_blob.go
@@ -1,0 +1,92 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package audittrail
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/paygate/internal/gpgx"
+	"github.com/moov-io/paygate/pkg/config"
+	"github.com/moov-io/paygate/pkg/transfers/pipeline/output"
+	"github.com/moov-io/paygate/pkg/transfers/pipeline/transform"
+	"golang.org/x/crypto/openpgp"
+
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/azureblob"
+	_ "gocloud.dev/blob/fileblob"
+	_ "gocloud.dev/blob/gcsblob"
+	_ "gocloud.dev/blob/memblob"
+	_ "gocloud.dev/blob/s3blob"
+)
+
+// blobStorage implements Storage with gocloud.dev/blob which allows
+// clients to use AWS S3, GCP Storage, and Azure Storage.
+type blobStorage struct {
+	bucket          *blob.Bucket
+	outputFormatter *output.NACHA
+	pubKey          openpgp.EntityList
+}
+
+func newBlobStorage(cfg *config.AuditTrail) (*blobStorage, error) {
+	storage := &blobStorage{
+		outputFormatter: &output.NACHA{},
+	}
+
+	bucket, err := blob.OpenBucket(context.Background(), cfg.BucketURI)
+	if err != nil {
+		return nil, err
+	}
+	storage.bucket = bucket
+
+	if cfg.GPG != nil {
+		pubKey, err := gpgx.ReadArmoredKeyFile(cfg.GPG.KeyFile)
+		if err != nil {
+			return nil, err
+		}
+		storage.pubKey = pubKey
+	}
+	return storage, nil
+}
+
+func (bs *blobStorage) Close() error {
+	if bs == nil {
+		return nil
+	}
+	return bs.bucket.Close()
+}
+
+func (bs *blobStorage) SaveFile(filename string, file *ach.File) error {
+	result := &transform.Result{File: file}
+
+	var buf bytes.Buffer
+	if err := bs.outputFormatter.Format(&buf, result); err != nil {
+		return err
+	}
+
+	encrypted, err := gpgx.Encrypt(buf.Bytes(), bs.pubKey)
+	if err != nil {
+		return err
+	}
+
+	// write the file in a sub-path of the yyy-mm-dd
+	path := fmt.Sprintf("audit-trail/%s/%s", time.Now().Format("2006-01-02"), filename)
+	w, err := bs.bucket.NewWriter(context.Background(), path, nil)
+	if err != nil {
+		return err
+	}
+
+	_, copyErr := w.Write(encrypted)
+	closeErr := w.Close()
+
+	if copyErr != nil || closeErr != nil {
+		return fmt.Errorf("copyErr=%v closeErr=%v", copyErr, closeErr)
+	}
+
+	return nil
+}

--- a/pkg/transfers/pipeline/audittrail/storage_blob_test.go
+++ b/pkg/transfers/pipeline/audittrail/storage_blob_test.go
@@ -1,0 +1,70 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package audittrail
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/paygate/pkg/config"
+)
+
+var (
+	keyPath = filepath.Join("..", "..", "..", "..", "internal", "gpgx", "testdata", "moov.pub")
+	ppdPath = filepath.Join("..", "..", "..", "..", "testdata", "ppd-debit.ach")
+)
+
+func TestBlobStorage(t *testing.T) {
+	cfg := &config.AuditTrail{
+		BucketURI: "mem://",
+		GPG: &config.GPG{
+			KeyFile: keyPath,
+		},
+	}
+	store, err := newBlobStorage(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	file, err := ach.ReadFile(ppdPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.SaveFile("saved.ach", file); err != nil {
+		t.Fatal(err)
+	}
+
+	path := fmt.Sprintf("audit-trail/%s/saved.ach", time.Now().Format("2006-01-02"))
+	r, err := store.bucket.NewReader(context.Background(), path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	bs, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(bs, []byte("BEGIN PGP MESSAGE")) {
+		t.Errorf("unexpected blob\n%s", string(bs))
+	}
+}
+
+func TestBlobStorageErr(t *testing.T) {
+	cfg := &config.AuditTrail{
+		BucketURI: "bad://",
+	}
+	if _, err := NewStorage(cfg); err == nil {
+		t.Error("expected error")
+	}
+}

--- a/pkg/transfers/pipeline/audittrail/storage_mock.go
+++ b/pkg/transfers/pipeline/audittrail/storage_mock.go
@@ -1,0 +1,21 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package audittrail
+
+import (
+	"github.com/moov-io/ach"
+)
+
+type MockStorage struct {
+	Err error
+}
+
+func (s *MockStorage) Close() error {
+	return s.Err
+}
+
+func (s *MockStorage) SaveFile(filename string, file *ach.File) error {
+	return s.Err
+}

--- a/pkg/transfers/pipeline/audittrail/storage_test.go
+++ b/pkg/transfers/pipeline/audittrail/storage_test.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package audittrail
+
+import (
+	"testing"
+
+	"github.com/moov-io/paygate/pkg/config"
+)
+
+func TestStorageErr(t *testing.T) {
+	if store, err := NewStorage(nil); store == nil || err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if store, err := NewStorage(&config.AuditTrail{}); store != nil || err == nil {
+		t.Errorf("unexpected store: %v", store)
+	}
+}


### PR DESCRIPTION
This allows storing (and encrypting) every uploaded file which is required by many agreements with an FI in production.

File retention after upload is not part of this storage.