### PR TITLE
transfers/inbound: cleanup empty dirs after download attempts

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -116,8 +116,10 @@ odfi:
       [ create05: <boolean> | default = false ]
 
   storage:
-    # Should we delete the local directory after processing is finished.
+    # Should we delete the local temporary directory after inbound processing is finished.
     # Leaving these files around helps debugging, but also exposes customer information.
+    # Empty directories are deleted and if no files are downloaded the entire temporary
+    # directory is removed.
     [ cleanup_local_directory: <boolean> | default = false ]
 
     # Should we delete the remote file on an ODFI's server after downloading and processing of each file.

--- a/pkg/transfers/inbound/cleanup_test.go
+++ b/pkg/transfers/inbound/cleanup_test.go
@@ -23,7 +23,7 @@ func TestCleanupErr(t *testing.T) {
 
 	dir, _ := ioutil.TempDir("", "clenaup-testing")
 	dl := &downloadedFiles{dir: dir}
-	defer dl.Close()
+	defer dl.deleteFiles()
 
 	// write a test file to attempt deletion
 	path := filepath.Join(dl.dir, agent.InboundPath())

--- a/pkg/transfers/inbound/download_test.go
+++ b/pkg/transfers/inbound/download_test.go
@@ -17,7 +17,7 @@ import (
 func TestDownloader__deleteFiles(t *testing.T) {
 	factory := &downloaderImpl{
 		logger:  log.NewNopLogger(),
-		baseDir: testDownloader(t),
+		baseDir: testDir(t),
 	}
 
 	agent := &upload.MockAgent{}
@@ -48,7 +48,7 @@ func TestDownloader__deleteFiles(t *testing.T) {
 func TestDownloader__deleteEmptyDirs(t *testing.T) {
 	factory := &downloaderImpl{
 		logger:  log.NewNopLogger(),
-		baseDir: testDownloader(t),
+		baseDir: testDir(t),
 	}
 
 	agent := &upload.MockAgent{}
@@ -83,7 +83,7 @@ func TestDownloader__deleteEmptyDirs(t *testing.T) {
 	}
 }
 
-func testDownloader(t *testing.T) string {
+func testDir(t *testing.T) string {
 	dir, err := ioutil.TempDir("", "downloader")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/transfers/inbound/download_test.go
+++ b/pkg/transfers/inbound/download_test.go
@@ -1,0 +1,93 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package inbound
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/moov-io/paygate/pkg/upload"
+)
+
+func TestDownloader__deleteFiles(t *testing.T) {
+	factory := &downloaderImpl{
+		logger:  log.NewNopLogger(),
+		baseDir: testDownloader(t),
+	}
+
+	agent := &upload.MockAgent{}
+	dl, err := factory.setup(agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// write a file and expect it to be deleted
+	path := filepath.Join(dl.dir, agent.InboundPath(), "foo.ach")
+	if err := ioutil.WriteFile(path, []byte("testing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := dl.deleteFiles(); err != nil {
+		t.Fatal(err)
+	}
+
+	// read files
+	fds, err := ioutil.ReadDir(dl.dir)
+	if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if len(fds) != 0 {
+		t.Errorf("%d unexpected files", len(fds))
+	}
+}
+
+func TestDownloader__deleteEmptyDirs(t *testing.T) {
+	factory := &downloaderImpl{
+		logger:  log.NewNopLogger(),
+		baseDir: testDownloader(t),
+	}
+
+	agent := &upload.MockAgent{}
+	dl, err := factory.setup(agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// write a file and expect it to be deleted
+	path := filepath.Join(dl.dir, agent.InboundPath(), "foo.ach")
+	if err := ioutil.WriteFile(path, []byte("testing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := dl.deleteEmptyDirs(agent); err != nil {
+		t.Fatal(err)
+	}
+
+	// read files
+	fds, err := ioutil.ReadDir(dl.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fds) != 1 {
+		t.Fatalf("%d unexpected files", len(fds))
+	}
+	if n := fds[0].Name(); n != "inbound" {
+		t.Errorf("unexpected %v", n)
+	}
+	// Check the file still exists
+	if _, err := os.Stat(path); err != nil {
+		t.Error(err)
+	}
+}
+
+func testDownloader(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "downloader")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}

--- a/pkg/transfers/inbound/mock_processor.go
+++ b/pkg/transfers/inbound/mock_processor.go
@@ -1,0 +1,21 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package inbound
+
+import (
+	"github.com/moov-io/ach"
+)
+
+type MockProcessor struct {
+	Err error
+}
+
+func (pc *MockProcessor) Type() string {
+	return "mock"
+}
+
+func (pc *MockProcessor) Handle(file *ach.File) error {
+	return pc.Err
+}

--- a/pkg/transfers/inbound/processor.go
+++ b/pkg/transfers/inbound/processor.go
@@ -66,8 +66,12 @@ func process(dir string, fileProcessors Processors) error {
 	for i := range infos {
 		file, err := ach.ReadFile(filepath.Join(dir, infos[i].Name()))
 		if err != nil {
-			el.Add(fmt.Errorf("problem opening %s: %v", infos[i].Name(), err))
-			continue
+			// Some return files don't contain FileHeader info, but can be processed as there
+			// are batches with entries. Let's continue to process those, but skip other errors.
+			if !base.Has(err, ach.ErrFileHeader) {
+				el.Add(fmt.Errorf("problem opening %s: %v", infos[i].Name(), err))
+				continue
+			}
 		}
 		if err := fileProcessors.HandleAll(file); err != nil {
 			el.Add(fmt.Errorf("processing %s error: %v", infos[i].Name(), err))

--- a/pkg/transfers/inbound/processor_test.go
+++ b/pkg/transfers/inbound/processor_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package inbound
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
+
+func TestProcessor__process(t *testing.T) {
+	dir := testDir(t)
+	if err := ioutil.WriteFile(filepath.Join(dir, "invalid.ach"), []byte("invalid-ach-file"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	processors := SetupProcessors(&MockProcessor{})
+
+	// By reading a file without ACH FileHeaders we still want to try and process
+	// Batches inside of it if any are found, so reading this kind of file shouldn't
+	// return an error from reading the file.
+	if err := process(dir, processors); err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/transfers/inbound/scheduler.go
+++ b/pkg/transfers/inbound/scheduler.go
@@ -89,8 +89,13 @@ func (s *PeriodicScheduler) tick() error {
 	if err != nil {
 		return fmt.Errorf("ERROR: problem moving files: %v", err)
 	}
-	if s.cfg.Storage != nil && s.cfg.Storage.CleanupLocalDirectory {
-		defer dl.Close()
+
+	if s.cfg.Storage != nil {
+		if s.cfg.Storage.CleanupLocalDirectory {
+			defer dl.deleteFiles()
+		} else {
+			defer dl.deleteEmptyDirs(s.agent)
+		}
 	}
 
 	if err := ProcessFiles(dl, s.processors); err != nil {

--- a/pkg/transfers/inbound/scheduler.go
+++ b/pkg/transfers/inbound/scheduler.go
@@ -102,7 +102,7 @@ func (s *PeriodicScheduler) tick() error {
 		return fmt.Errorf("ERROR: processing files: %v", err)
 	}
 
-	if !s.cfg.Storage.KeepRemoteFiles {
+	if s.cfg.Storage != nil && !s.cfg.Storage.KeepRemoteFiles {
 		if err := Cleanup(s.logger, s.agent, dl); err != nil {
 			return fmt.Errorf("ERROR: deleting remote files: %v", err)
 		}

--- a/pkg/transfers/inbound/scheduler_test.go
+++ b/pkg/transfers/inbound/scheduler_test.go
@@ -1,0 +1,39 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package inbound
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moov-io/paygate/pkg/config"
+	"github.com/moov-io/paygate/pkg/upload"
+)
+
+func TestScheduler(t *testing.T) {
+	cfg := config.Empty()
+	cfg.ODFI.Inbound.Interval = 10 * time.Second
+	cfg.ODFI.Storage = &config.Storage{
+		CleanupLocalDirectory: true,
+		KeepRemoteFiles:       false,
+	}
+
+	agent := &upload.MockAgent{}
+	processors := SetupProcessors(&MockProcessor{})
+
+	schd := NewPeriodicScheduler(cfg, agent, processors)
+	if schd == nil {
+		t.Fatal("nil Scheduler")
+	}
+
+	ss, ok := schd.(*PeriodicScheduler)
+	if !ok {
+		t.Fatalf("unexpected scheduler: %T", schd)
+	}
+
+	if err := ss.tick(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
I noticed with `storage.cleanup_local_directory: false` in the config the download directory is left unchanged. This was intended to keep **downloaded files**, but not empty directories. Let's cleanup those empty directories and keep files. 