### PR TITLE
transfers/admin: allow status change of: Pending -> Reviewable

### DIFF
--- a/api/openapi-admin.yaml
+++ b/api/openapi-admin.yaml
@@ -115,7 +115,10 @@ paths:
     put:
       tags: [Transfers]
       summary: Update Transfer status
-      description: Updates a Transfer status for the specified userId and transferId
+      description: |+
+          Updates a Transfer status for the specified userId and transferId.
+          PENDING transfers may be updated to: CANCELED or REVIEWABLE.
+          REVIEWABLE transfers may be updated to: CANCELED or PENDING.
       operationId: updateTransferStatus
       parameters:
         - name: transferId

--- a/pkg/admin/api_transfers.go
+++ b/pkg/admin/api_transfers.go
@@ -106,7 +106,7 @@ type UpdateTransferStatusOpts struct {
 
 /*
 UpdateTransferStatus Update Transfer status
-Updates a Transfer status for the specified userId and transferId
+Updates a Transfer status for the specified userId and transferId. PENDING transfers may be updated to: CANCELED or REVIEWABLE. REVIEWABLE transfers may be updated to: CANCELED or PENDING.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param transferId transferID that identifies the Transfer
  * @param xUserID Unique userID set by an auth proxy or client to identify and isolate objects.

--- a/pkg/admin/docs/TransfersApi.md
+++ b/pkg/admin/docs/TransfersApi.md
@@ -45,7 +45,7 @@ No authorization required
 
 Update Transfer status
 
-Updates a Transfer status for the specified userId and transferId
+Updates a Transfer status for the specified userId and transferId. PENDING transfers may be updated to: CANCELED or REVIEWABLE. REVIEWABLE transfers may be updated to: CANCELED or PENDING. 
 
 ### Required Parameters
 

--- a/pkg/transfers/admin/approval.go
+++ b/pkg/transfers/admin/approval.go
@@ -63,9 +63,9 @@ func updateTransferStatus(logger log.Logger, repo transfers.Repository) http.Han
 	}
 }
 
-func validStatusTransistion(transferID string, incoming client.TransferStatus, proposed client.TransferStatus) error {
+func validStatusTransistion(transferID string, current client.TransferStatus, proposed client.TransferStatus) error {
 	// We only allow a couple of transitions for Transfer statuses as there are several
-	switch incoming {
+	switch current {
 	case client.REVIEWABLE:
 		// Reviewable transfers can only be moved to pending or canceled after a human has confirmed
 		// the Transfer can be sent off.
@@ -77,9 +77,10 @@ func validStatusTransistion(transferID string, incoming client.TransferStatus, p
 		}
 	case client.PENDING:
 		// Pending transfers can only be canceled as if they're already sent we can't undo that.
-		if proposed == client.CANCELED {
+		switch proposed {
+		case client.CANCELED, client.REVIEWABLE:
 			return nil
 		}
 	}
-	return fmt.Errorf("unable to move transfer=%s from status=%s to status=%s", transferID, incoming, proposed)
+	return fmt.Errorf("unable to move transfer=%s from status=%s to status=%s", transferID, current, proposed)
 }

--- a/pkg/transfers/admin/approval_test.go
+++ b/pkg/transfers/admin/approval_test.go
@@ -77,4 +77,9 @@ func TestAdmin__validStatusTransistion(t *testing.T) {
 	if err := validStatusTransistion(transferID, client.REVIEWABLE, client.PROCESSED); err == nil {
 		t.Error("expected error")
 	}
+
+	// Pending to Reviewable
+	if err := validStatusTransistion(transferID, client.PENDING, client.REVIEWABLE); err != nil {
+		t.Error(err)
+	}
 }


### PR DESCRIPTION
We should allow the workflow of requiring a review on a pending transfer. 