### PR TITLE
transfers/limiter: add initial setup for rejecting Transfers by their Amounts

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -170,7 +170,7 @@ func main() {
 	// Transfers
 	transfersRepo := transfers.NewRepo(db)
 	defer transfersRepo.Close()
-	transfers.NewRouter(cfg.Logger, transfersRepo, tenantsRepo, customersClient, accountDecryptor, fundflowStrategy, transferPublisher).RegisterRoutes(handler)
+	transfers.NewRouter(cfg, transfersRepo, tenantsRepo, customersClient, accountDecryptor, fundflowStrategy, transferPublisher).RegisterRoutes(handler)
 	transferadmin.RegisterRoutes(cfg.Logger, adminServer, transfersRepo)
 
 	// Micro-Deposit Validation

--- a/docs/config.md
+++ b/docs/config.md
@@ -144,6 +144,19 @@ odfi:
       [ directory: <filename> ]
 ```
 
+### Transfers
+
+```yaml
+transfers:
+  limits:
+    fixed:
+      # Transfer whose amount exceeds this value are created with the REVIEWABLE status
+      # for manual approval prior to upload.
+      softLimit: "5000.00"
+
+      # No Transfer amount is allowed to exceed this value.
+      hardLimit: "10000.00"
+```
 ### Pipeline
 
 ```yaml

--- a/docs/config.md
+++ b/docs/config.md
@@ -149,13 +149,17 @@ odfi:
 ```yaml
 transfers:
   limits:
+    # Fixed limits reject or force a manual review of Transfers if their amount exceeds
+    # the configured hard or soft limit respectively.
     fixed:
       # Transfer whose amount exceeds this value are created with the REVIEWABLE status
       # for manual approval prior to upload.
-      softLimit: "5000.00"
+      # Example: USD 2500.00
+      softLimit: <string>
 
       # No Transfer amount is allowed to exceed this value.
-      hardLimit: "10000.00"
+      # Example: USD 10000.00
+      hardLimit: <string>
 ```
 ### Pipeline
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -30,7 +30,7 @@ odfi:
       - "16:20" # 4:20pm EST
   inbound:
     interval: "10m"
-  transfers:
+  fileConfig:
     balanceEntries: true
   ftp:
     hostname: "ftp:2121"

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -45,6 +45,11 @@ odfi:
     keepRemoteFiles: false
     local:
       directory: "./storage/"
+transfers:
+  limits:
+    fixed:
+      softLimit: "5000.00"
+      hardLimit: "10000.00"
 validation:
   microDeposits:
     source:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -48,8 +48,8 @@ odfi:
 transfers:
   limits:
     fixed:
-      softLimit: "5000.00"
-      hardLimit: "10000.00"
+      softLimit: "USD 5000.00"
+      hardLimit: "USD 10000.00"
 validation:
   microDeposits:
     source:

--- a/pkg/achx/files.go
+++ b/pkg/achx/files.go
@@ -34,7 +34,7 @@ type Destination struct {
 type Options struct {
 	ODFIRoutingNumber string
 	Gateway           config.Gateway
-	FileConfig        config.Transfers
+	FileConfig        config.FileConfig
 	CutoffTimezone    *time.Location
 }
 

--- a/pkg/achx/files_test.go
+++ b/pkg/achx/files_test.go
@@ -28,7 +28,7 @@ func TestFiles__ConstructFile(t *testing.T) {
 			OriginName:      "My Bank",
 			DestinationName: "Their Bank",
 		},
-		FileConfig: config.Transfers{
+		FileConfig: config.FileConfig{
 			BalanceEntries: true,
 		},
 	}

--- a/pkg/achx/ppd_test.go
+++ b/pkg/achx/ppd_test.go
@@ -17,7 +17,7 @@ import (
 func TestPPD__entry(t *testing.T) {
 	opts := Options{
 		ODFIRoutingNumber: "987654320",
-		FileConfig: config.Transfers{
+		FileConfig: config.FileConfig{
 			Addendum: config.Addendum{
 				Create05: true,
 			},
@@ -64,7 +64,7 @@ func TestPPD__entry(t *testing.T) {
 func TestPPD__offset(t *testing.T) {
 	opts := Options{
 		ODFIRoutingNumber: "987654320",
-		FileConfig: config.Transfers{
+		FileConfig: config.FileConfig{
 			BalanceEntries: true,
 			Addendum: config.Addendum{
 				Create05: true,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 
 	ODFI       ODFI
 	Pipeline   Pipeline
+	Transfers  Transfers
 	Validation Validation
 
 	Customers Customers

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,6 +119,9 @@ func (cfg *Config) Validate() error {
 	if err := cfg.Pipeline.Validate(); err != nil {
 		return fmt.Errorf("pipeline: %v", err)
 	}
+	if err := cfg.Transfers.Validate(); err != nil {
+		return fmt.Errorf("transfers: %v", err)
+	}
 	if err := cfg.Validation.Validate(); err != nil {
 		return fmt.Errorf("validation: %v", err)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,7 +5,6 @@
 package config
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -158,8 +157,6 @@ odfi:
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	fmt.Printf("%#v\n", cfg.Customers)
 
 	if v := cfg.ODFI.OutboundPath; v != "/files/outbound/" {
 		t.Errorf("ODFI OutboundPath: %q", v)

--- a/pkg/config/odfi.go
+++ b/pkg/config/odfi.go
@@ -54,7 +54,7 @@ type ODFI struct {
 
 	Inbound Inbound
 
-	Transfers Transfers
+	FileConfig FileConfig
 
 	Storage *Storage
 }
@@ -203,7 +203,7 @@ type Inbound struct {
 	Interval time.Duration
 }
 
-type Transfers struct {
+type FileConfig struct {
 	BalanceEntries bool
 	Addendum       Addendum
 }

--- a/pkg/config/transfers.go
+++ b/pkg/config/transfers.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package config
+
+import (
+	"github.com/moov-io/paygate/pkg/model"
+)
+
+type Transfers struct {
+	Limits Limits
+}
+
+type Limits struct {
+	Fixed *FixedLimits
+}
+
+type FixedLimits struct {
+	// SoftLimit is a numerical value which is used to force created Transfer
+	// objects into the REVIEWABLE status for manual approval prior to upload.
+	SoftLimit string
+
+	// HardLimit is a numerical value. No Transfer amount is allowed to exceed this value.
+	HardLimit string
+}
+
+func (cfg *FixedLimits) OverSoftLimit(amt *model.Amount) (bool, error) {
+	return cfg.overLimit(cfg.SoftLimit, amt)
+}
+
+func (cfg *FixedLimits) OverHardLimit(amt *model.Amount) (bool, error) {
+	return cfg.overLimit(cfg.HardLimit, amt)
+}
+
+func (cfg *FixedLimits) overLimit(limit string, amt *model.Amount) (bool, error) {
+	lmt, err := model.ParseAmount(limit)
+	if err != nil {
+		return true, err
+	}
+	return amt.Int() > lmt.Int(), nil
+}

--- a/pkg/config/transfers.go
+++ b/pkg/config/transfers.go
@@ -5,6 +5,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/moov-io/paygate/pkg/model"
 )
 
@@ -12,8 +14,22 @@ type Transfers struct {
 	Limits Limits
 }
 
+func (cfg Transfers) Validate() error {
+	if err := cfg.Limits.Validate(); err != nil {
+		return fmt.Errorf("limits: %v", err)
+	}
+	return nil
+}
+
 type Limits struct {
 	Fixed *FixedLimits
+}
+
+func (cfg Limits) Validate() error {
+	if err := cfg.Fixed.Validate(); err != nil {
+		return fmt.Errorf("fixed limits: %v", err)
+	}
+	return nil
 }
 
 type FixedLimits struct {
@@ -23,6 +39,19 @@ type FixedLimits struct {
 
 	// HardLimit is a numerical value. No Transfer amount is allowed to exceed this value.
 	HardLimit string
+}
+
+func (cfg *FixedLimits) Validate() error {
+	if cfg == nil {
+		return nil
+	}
+	if _, err := model.ParseAmount(cfg.SoftLimit); err != nil {
+		return fmt.Errorf("soft limit: %v", err)
+	}
+	if _, err := model.ParseAmount(cfg.HardLimit); err != nil {
+		return fmt.Errorf("hard limit: %v", err)
+	}
+	return nil
 }
 
 func (cfg *FixedLimits) OverSoftLimit(amt *model.Amount) (bool, error) {

--- a/pkg/config/transfers_test.go
+++ b/pkg/config/transfers_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/moov-io/paygate/pkg/model"
+)
+
+func TestFixedLimits__Soft(t *testing.T) {
+	cfg := &FixedLimits{
+		SoftLimit: "USD 104.23",
+	}
+	amt, _ := model.NewAmount("USD", "101.00")
+	if over, err := cfg.OverSoftLimit(amt); over || err != nil {
+		t.Errorf("expected amount to pass: %v", err)
+	}
+
+	// exceed limit
+	amt, _ = model.NewAmount("USD", "120.01")
+	if over, err := cfg.OverSoftLimit(amt); !over || err != nil {
+		t.Errorf("expected error: %v", err)
+	}
+}
+
+func TestFixedLimits__Hard(t *testing.T) {
+	cfg := &FixedLimits{
+		HardLimit: "USD 104.23",
+	}
+	amt, _ := model.NewAmount("USD", "101.00")
+	if over, err := cfg.OverHardLimit(amt); over || err != nil {
+		t.Errorf("expected amount to pass: %v", err)
+	}
+
+	// exceed limit
+	amt, _ = model.NewAmount("USD", "120.01")
+	if over, err := cfg.OverHardLimit(amt); !over || err != nil {
+		t.Errorf("expected error: %v", err)
+	}
+}
+
+func TestFixedLimitsErr(t *testing.T) {
+	cfg := &FixedLimits{
+		SoftLimit: "invalid",
+	}
+	if _, err := cfg.overLimit(cfg.SoftLimit, nil); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/pkg/config/transfers_test.go
+++ b/pkg/config/transfers_test.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/moov-io/paygate/pkg/model"
@@ -48,5 +49,38 @@ func TestFixedLimitsErr(t *testing.T) {
 	}
 	if _, err := cfg.overLimit(cfg.SoftLimit, nil); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestFixedLimits__Validate(t *testing.T) {
+	cfg := &Transfers{
+		Limits: Limits{
+			Fixed: &FixedLimits{
+				SoftLimit: "invalid",
+			},
+		},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error")
+	} else {
+		if !strings.Contains(err.Error(), "soft limit:") {
+			t.Errorf("unexpected error: %q", err)
+		}
+	}
+
+	// verify hard limit fails too
+	cfg.Limits.Fixed.SoftLimit = "USD 1.23"
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error")
+	} else {
+		if !strings.Contains(err.Error(), "hard limit:") {
+			t.Errorf("unexpected error: %q", err)
+		}
+	}
+
+	// fully successful
+	cfg.Limits.Fixed.HardLimit = "USD 100.00"
+	if err := cfg.Validate(); err != nil {
+		t.Error(err)
 	}
 }

--- a/pkg/transfers/fundflow/first_party.go
+++ b/pkg/transfers/fundflow/first_party.go
@@ -71,14 +71,14 @@ func (fp *FirstParty) Originate(companyID string, xfer *client.Transfer, src Sou
 	opts := achx.Options{
 		ODFIRoutingNumber: fp.cfg.RoutingNumber,
 		Gateway:           fp.cfg.Gateway,
-		FileConfig:        fp.cfg.Transfers,
+		FileConfig:        fp.cfg.FileConfig,
 		CutoffTimezone:    fp.cfg.Cutoffs.Location(),
 	}
 	// Balance entries from transfers which appear to not be "account validation" (aka micro-deposits).
 	// Right now we're doing this by checking the amount which obviously isn't ideal.
 	//
 	// TODO(adam): Better detection for when to offset or not.
-	opts.FileConfig.BalanceEntries = fp.cfg.Transfers.BalanceEntries && (xfer.Amount >= "USD 0.50")
+	opts.FileConfig.BalanceEntries = fp.cfg.FileConfig.BalanceEntries && (xfer.Amount >= "USD 0.50")
 
 	file, err := achx.ConstructFile(xfer.TransferID, opts, companyID, xfer, source, destination)
 	if err != nil {

--- a/pkg/transfers/limiter/fixed.go
+++ b/pkg/transfers/limiter/fixed.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package limiter
+
+import (
+	"fmt"
+
+	"github.com/moov-io/paygate/pkg/client"
+	"github.com/moov-io/paygate/pkg/config"
+	"github.com/moov-io/paygate/pkg/model"
+)
+
+type fixedLimiter struct {
+	cfg *config.FixedLimits
+}
+
+func newFixedLimiter(cfg *config.FixedLimits) (Checker, error) {
+	return &fixedLimiter{cfg: cfg}, nil
+}
+
+func (l *fixedLimiter) Accept(userID string, xfer *client.Transfer) error {
+	amt, err := model.ParseAmount(xfer.Amount)
+	if err != nil {
+		return fmt.Errorf("fixedLimiter: unable to parse transfer amount: %v", err)
+	}
+	if ok, err := l.cfg.OverHardLimit(amt); !ok || err != nil {
+		if !ok {
+			return fmt.Errorf("fixedLimiter: %v", ErrRejectTransfer)
+		}
+		if err != nil {
+			return fmt.Errorf("fixedLimiter: hard limit parsing error: %v", err)
+		}
+	} else {
+		// soft limit checks
+		if ok, err := l.cfg.OverSoftLimit(amt); !ok && err == nil {
+			return fmt.Errorf("fixedLimiter: %v", ErrReviewableTransfer)
+		} else {
+			if err != nil {
+				return fmt.Errorf("fixedLimiter: soft limit parsing error: %v", err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/transfers/limiter/fixed_test.go
+++ b/pkg/transfers/limiter/fixed_test.go
@@ -1,0 +1,55 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package limiter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/moov-io/base"
+	"github.com/moov-io/paygate/pkg/client"
+	"github.com/moov-io/paygate/pkg/config"
+)
+
+func TestFixedLimiter(t *testing.T) {
+	limit, err := newFixedLimiter(&config.FixedLimits{
+		SoftLimit: "USD 1.11",
+		HardLimit: "USD 2.22",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userID := base.ID()
+	xfer := &client.Transfer{
+		Amount: "USD 1.00",
+	}
+	// successful transfer
+	if err := limit.Accept(userID, xfer); err != nil {
+		t.Fatal(err)
+	}
+
+	// reviewable transfer
+	xfer.Amount = "USD 1.33"
+	if err := limit.Accept(userID, xfer); err != nil {
+		if !strings.Contains(err.Error(), ErrReviewableTransfer.Error()) {
+			t.Fatalf("unexpected error: %q", err)
+		}
+	}
+
+	// reject Transfer
+	xfer.Amount = "USD 4.56"
+	if err := limit.Accept(userID, xfer); err != nil {
+		if !strings.Contains(err.Error(), ErrOverLimits.Error()) {
+			t.Fatalf("unexpected error: %q", err)
+		}
+	}
+}
+
+func TestFixedLimiterErr(t *testing.T) {
+	if _, err := newFixedLimiter(&config.FixedLimits{}); err == nil {
+		t.Error("expected error")
+	}
+}

--- a/pkg/transfers/limiter/limiter.go
+++ b/pkg/transfers/limiter/limiter.go
@@ -1,0 +1,35 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package limiter
+
+import (
+	"errors"
+
+	"github.com/moov-io/paygate/pkg/client"
+	"github.com/moov-io/paygate/pkg/config"
+)
+
+var (
+	ErrReviewableTransfer = errors.New("require manual review")
+	ErrRejectTransfer     = errors.New("rejected transfer - over limit")
+)
+
+type Checker interface {
+	Accept(userID string, xfer *client.Transfer) error
+}
+
+func New(cfg config.Limits) (Checker, error) {
+	if cfg.Fixed != nil {
+		return newFixedLimiter(cfg.Fixed)
+	}
+	return &passingLimiter{}, nil
+}
+
+type passingLimiter struct{}
+
+// Accept always returns no error for the passingLimiter
+func (l *passingLimiter) Accept(userID string, xfer *client.Transfer) error {
+	return nil
+}

--- a/pkg/transfers/limiter/limiter.go
+++ b/pkg/transfers/limiter/limiter.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	ErrReviewableTransfer = errors.New("require manual review")
-	ErrRejectTransfer     = errors.New("rejected transfer - over limit")
+	ErrOverLimits         = errors.New("rejected transfer - over all limits")
 )
 
 type Checker interface {

--- a/pkg/transfers/router.go
+++ b/pkg/transfers/router.go
@@ -56,7 +56,9 @@ func NewRouter(
 ) *Router {
 	limitChecker, err := limiter.New(cfg.Transfers.Limits)
 	if err != nil {
-		cfg.Logger.Log("transfers", fmt.Sprintf("problem creating transfer limiter: %v", err))
+		err = fmt.Errorf("problem creating transfer limiter: %v", err)
+		cfg.Logger.Log("transfers", err)
+		panic(err.Error())
 	}
 	cfg.Logger.Log("transfers", fmt.Sprintf("setup %T limit checker", limitChecker))
 	return &Router{

--- a/pkg/transfers/router_test.go
+++ b/pkg/transfers/router_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moov-io/base"
 	moovcustomers "github.com/moov-io/customers/client"
 	"github.com/moov-io/paygate/pkg/client"
+	"github.com/moov-io/paygate/pkg/config"
 	"github.com/moov-io/paygate/pkg/customers"
 	"github.com/moov-io/paygate/pkg/customers/accounts"
 	"github.com/moov-io/paygate/pkg/tenants"
@@ -23,7 +24,6 @@ import (
 	"github.com/moov-io/paygate/pkg/transfers/pipeline"
 	"github.com/moov-io/paygate/pkg/util"
 
-	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
 )
 
@@ -113,7 +113,7 @@ func TestRouter__getUserTransfers(t *testing.T) {
 	customersClient := mockCustomersClient()
 
 	r := mux.NewRouter()
-	router := NewRouter(log.NewNopLogger(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
+	router := NewRouter(config.Empty(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
 	router.RegisterRoutes(r)
 
 	c := testclient.New(t, r)
@@ -182,7 +182,7 @@ func TestRouter__createUserTransfer(t *testing.T) {
 	customersClient := mockCustomersClient()
 
 	r := mux.NewRouter()
-	router := NewRouter(log.NewNopLogger(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
+	router := NewRouter(config.Empty(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
 	router.RegisterRoutes(r)
 
 	c := testclient.New(t, r)
@@ -216,7 +216,7 @@ func TestRouter__createUserTransfersInvalidAmount(t *testing.T) {
 	customersClient := mockCustomersClient()
 
 	r := mux.NewRouter()
-	router := NewRouter(log.NewNopLogger(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
+	router := NewRouter(config.Empty(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
 	router.RegisterRoutes(r)
 
 	c := testclient.New(t, r)
@@ -239,7 +239,7 @@ func TestRouter__MissingSource(t *testing.T) {
 	customersClient := mockCustomersClient()
 
 	r := mux.NewRouter()
-	router := NewRouter(log.NewNopLogger(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
+	router := NewRouter(config.Empty(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
 	router.RegisterRoutes(r)
 
 	c := testclient.New(t, r)
@@ -265,7 +265,7 @@ func TestRouter__MissingDestination(t *testing.T) {
 	customersClient := mockCustomersClient()
 
 	r := mux.NewRouter()
-	router := NewRouter(log.NewNopLogger(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
+	router := NewRouter(config.Empty(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
 	router.RegisterRoutes(r)
 
 	c := testclient.New(t, r)
@@ -301,7 +301,7 @@ func TestRouter__getUserTransfer(t *testing.T) {
 	customersClient := mockCustomersClient()
 
 	r := mux.NewRouter()
-	router := NewRouter(log.NewNopLogger(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
+	router := NewRouter(config.Empty(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
 	router.RegisterRoutes(r)
 
 	c := testclient.New(t, r)
@@ -321,7 +321,7 @@ func TestRouter__deleteUserTransfer(t *testing.T) {
 	customersClient := mockCustomersClient()
 
 	r := mux.NewRouter()
-	router := NewRouter(log.NewNopLogger(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
+	router := NewRouter(config.Empty(), repoWithTransfer, tenantRepo, customersClient, mockDecryptor, mockStrategy, fakePublisher)
 	router.RegisterRoutes(r)
 
 	c := testclient.New(t, r)


### PR DESCRIPTION
This is a change to support transfer limits in PayGate with an option to specify a different implementation. We use this currently with fixed amounts to reject transfers over a given dollar amount. 