### PR TITLE
validation/microdeposits: only allow when customer and account need validation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,8 @@ Before money can be transferred in the United States a few conditions must be ve
 
 To accomplish this PayGate relies on [Moov Customers](https://github.com/moov-io/customers) for tracking sensitive consumer/business information, [Moov Fed](https://github.com/moov-io/fed) for ABA routing number lookup, and [Moov Watchman](https://github.com/moov-io/watchman) for current sanctions policy restrictions.
 
+Micro-Deposits can only be initiated for a Customer in the `Unknown` status and an Account in the `None` status.
+
 See the [customer configuration section](./config.md#customers) for more information.
 
 ### Transfer Pipeline

--- a/pkg/customers/health_test.go
+++ b/pkg/customers/health_test.go
@@ -25,10 +25,10 @@ func TestHealthChecker(t *testing.T) {
 	}
 
 	// find a customer, but no account
-	client.Customer = &moovcustomers.Customer{
+	client.Customers = append(client.Customers, &moovcustomers.Customer{
 		CustomerID: customerID,
 		Status:     moovcustomers.VERIFIED,
-	}
+	})
 	if err := HealthChecker(client, customerID, accountID)(); err != nil {
 		if !strings.Contains(err.Error(), "unable to find accountID") {
 			t.Fatal(err)

--- a/pkg/customers/mock_client.go
+++ b/pkg/customers/mock_client.go
@@ -9,10 +9,10 @@ import (
 )
 
 type MockClient struct {
-	Accounts map[string]*moovcustomers.Account
-	Transit  *moovcustomers.TransitAccountNumber
-	Customer *moovcustomers.Customer
-	Result   *OfacSearch
+	Accounts  map[string]*moovcustomers.Account
+	Customers []*moovcustomers.Customer
+	Transit   *moovcustomers.TransitAccountNumber
+	Result    *OfacSearch
 
 	Err error
 }
@@ -25,7 +25,12 @@ func (c *MockClient) Lookup(customerID string, requestID string, userID string) 
 	if c.Err != nil {
 		return nil, c.Err
 	}
-	return c.Customer, nil
+	for i := range c.Customers {
+		if c.Customers[i].CustomerID == customerID {
+			return c.Customers[i], nil
+		}
+	}
+	return nil, nil
 }
 
 func (c *MockClient) FindAccount(customerID, accountID string) (*moovcustomers.Account, error) {

--- a/pkg/transfers/router.go
+++ b/pkg/transfers/router.go
@@ -195,7 +195,7 @@ func CreateUserTransfer(
 				responder.Problem(fmt.Errorf("creating transfer: error getting fundflow source: %v", err))
 				return
 			}
-			destination, err := GetFundflowDestination(customersClient, accountDecryptor, req.Destination)
+			destination, err := getFundflowDestination(customersClient, accountDecryptor, req.Destination)
 			if err != nil {
 				responder.Problem(fmt.Errorf("creating transfer: error getting destination: %v", err))
 				return
@@ -305,7 +305,7 @@ func GetFundflowSource(client customers.Client, accountDecryptor accounts.Decryp
 	return source, nil
 }
 
-func GetFundflowDestination(client customers.Client, accountDecryptor accounts.Decryptor, dst client.Destination) (fundflow.Destination, error) {
+func getFundflowDestination(client customers.Client, accountDecryptor accounts.Decryptor, dst client.Destination) (fundflow.Destination, error) {
 	var destination fundflow.Destination
 
 	// Set destination Customer

--- a/pkg/transfers/router_test.go
+++ b/pkg/transfers/router_test.go
@@ -30,7 +30,8 @@ import (
 )
 
 var (
-	sourceAccountID, destinationAccountID = base.ID(), base.ID()
+	sourceCustomerID, destinationCustomerID = base.ID(), base.ID()
+	sourceAccountID, destinationAccountID   = base.ID(), base.ID()
 
 	repoWithTransfer = &MockRepository{
 		Transfers: []*client.Transfer{
@@ -38,11 +39,11 @@ var (
 				TransferID: base.ID(),
 				Amount:     "USD 12.44",
 				Source: client.Source{
-					CustomerID: base.ID(),
+					CustomerID: sourceCustomerID,
 					AccountID:  sourceAccountID,
 				},
 				Destination: client.Destination{
-					CustomerID: base.ID(),
+					CustomerID: destinationCustomerID,
 					AccountID:  destinationAccountID,
 				},
 				Description: "test transfer",
@@ -64,12 +65,21 @@ var (
 func mockCustomersClient() *customers.MockClient {
 	client := &customers.MockClient{
 		Accounts: make(map[string]*moovcustomers.Account),
-		Customer: &moovcustomers.Customer{
-			CustomerID: base.ID(),
-			FirstName:  "John",
-			LastName:   "Doe",
-			Email:      "john.doe@example.com",
-			Status:     moovcustomers.VERIFIED,
+		Customers: []*moovcustomers.Customer{
+			{
+				CustomerID: sourceCustomerID,
+				FirstName:  "John",
+				LastName:   "Doe",
+				Email:      "john.doe@example.com",
+				Status:     moovcustomers.VERIFIED,
+			},
+			{
+				CustomerID: destinationCustomerID,
+				FirstName:  "Jane",
+				LastName:   "Doe",
+				Email:      "jane.doe@example.com",
+				Status:     moovcustomers.VERIFIED,
+			},
 		},
 	}
 	client.Accounts[sourceAccountID] = &moovcustomers.Account{
@@ -143,11 +153,11 @@ func TestRouter__createUserTransfer(t *testing.T) {
 	opts := client.CreateTransfer{
 		Amount: "USD 12.44",
 		Source: client.Source{
-			CustomerID: base.ID(),
+			CustomerID: sourceCustomerID,
 			AccountID:  sourceAccountID,
 		},
 		Destination: client.Destination{
-			CustomerID: base.ID(),
+			CustomerID: destinationCustomerID,
 			AccountID:  destinationAccountID,
 		},
 		Description: "test transfer",
@@ -200,11 +210,11 @@ func TestRouter__createUserTransferMissingFundflowStrategy(t *testing.T) {
 	opts := client.CreateTransfer{
 		Amount: "USD 12.44",
 		Source: client.Source{
-			CustomerID: base.ID(),
+			CustomerID: sourceCustomerID,
 			AccountID:  sourceAccountID,
 		},
 		Destination: client.Destination{
-			CustomerID: base.ID(),
+			CustomerID: destinationCustomerID,
 			AccountID:  destinationAccountID,
 		},
 		Description: "test transfer",
@@ -263,8 +273,8 @@ func TestRouter__MissingDestination(t *testing.T) {
 	opts := client.CreateTransfer{
 		Amount: "USD 12.54",
 		Source: client.Source{
-			CustomerID: base.ID(),
-			AccountID:  base.ID(),
+			CustomerID: sourceCustomerID,
+			AccountID:  sourceAccountID,
 		},
 		Destination: client.Destination{
 			CustomerID: base.ID(), // missing AccountID


### PR DESCRIPTION


It came up that we should reject initiating these when the Customer or
Account is rejected so the status check was off anyway.