### PR TITLE
change ports in docker-compose.yaml to allow for docker-compose up to work on windows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,8 +53,8 @@ services:
     image: oryd/mailslurper:latest-smtps
     ports:
       - '1025:1025'
-      - '4436:4436'
-      - '4437:4437'
+      - '4444:4436'
+      - '4445:4437'
   paygate:
     image: moov/paygate:v0.8.0
     ports:


### PR DESCRIPTION
https://github.com/moov-io/paygate/issues/544

When using Docker on Windows, there are specific ports that are reserved and cannot be used when running applications within a container on Windows. This PR adjusts those ports to ports not in the reserved range so docker-compose up will work on a fresh checkout of the repo.