### PR TITLE
transfers: rename getUserTransfers to getTransfers

### DIFF
--- a/pkg/transfers/mock_repository.go
+++ b/pkg/transfers/mock_repository.go
@@ -15,7 +15,7 @@ type MockRepository struct {
 	Err       error
 }
 
-func (r *MockRepository) getUserTransfers(namespace string, params transferFilterParams) ([]*client.Transfer, error) {
+func (r *MockRepository) getTransfers(namespace string, params transferFilterParams) ([]*client.Transfer, error) {
 	if r.Err != nil {
 		return nil, r.Err
 	}

--- a/pkg/transfers/repository.go
+++ b/pkg/transfers/repository.go
@@ -15,7 +15,7 @@ import (
 )
 
 type Repository interface {
-	getUserTransfers(namespace string, params transferFilterParams) ([]*client.Transfer, error)
+	getTransfers(namespace string, params transferFilterParams) ([]*client.Transfer, error)
 	GetTransfer(id string) (*client.Transfer, error)
 	UpdateTransferStatus(transferID string, status client.TransferStatus) error
 	WriteUserTransfer(namespace string, transfer *client.Transfer) error
@@ -43,7 +43,7 @@ func (r *sqlRepo) Close() error {
 	return r.db.Close()
 }
 
-func (r *sqlRepo) getUserTransfers(namespace string, params transferFilterParams) ([]*client.Transfer, error) {
+func (r *sqlRepo) getTransfers(namespace string, params transferFilterParams) ([]*client.Transfer, error) {
 	var statusQuery string
 	if string(params.Status) != "" {
 		statusQuery = "and status = ?"
@@ -73,14 +73,14 @@ order by created_at desc limit ? offset ?;`, statusQuery)
 	for rows.Next() {
 		var row string
 		if err := rows.Scan(&row); err != nil {
-			return transfers, fmt.Errorf("getUserTransfers scan: %v", err)
+			return transfers, fmt.Errorf("getTransfers scan: %v", err)
 		}
 		if row != "" {
 			transferIDs = append(transferIDs, row)
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return transfers, fmt.Errorf("getUserTransfers: rows.Err=%v", err)
+		return transfers, fmt.Errorf("getTransfers: rows.Err=%v", err)
 	}
 
 	// read each transferID

--- a/pkg/transfers/repository_test.go
+++ b/pkg/transfers/repository_test.go
@@ -15,13 +15,13 @@ import (
 	"github.com/moov-io/paygate/pkg/database"
 )
 
-func TestRepository__getUserTransfers(t *testing.T) {
+func TestRepository__getTransfers(t *testing.T) {
 	namespace := base.ID()
 	repo := setupSQLiteDB(t)
 	writeTransfer(t, namespace, repo)
 
 	params := readTransferFilterParams(&http.Request{})
-	xfers, err := repo.getUserTransfers(namespace, params)
+	xfers, err := repo.getTransfers(namespace, params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestRepository__getUserTransfers(t *testing.T) {
 	}
 }
 
-func TestRepository__getUserTransfersWithTraceNumbers(t *testing.T) {
+func TestRepository__getTransfersWithTraceNumbers(t *testing.T) {
 	namespace := base.ID()
 	repo := setupSQLiteDB(t)
 	transfer := writeTransfer(t, namespace, repo)
@@ -45,7 +45,7 @@ func TestRepository__getUserTransfersWithTraceNumbers(t *testing.T) {
 	saveTraceNumbers(t, transfer, traceNumbers, repo)
 
 	params := readTransferFilterParams(&http.Request{})
-	xfers, err := repo.getUserTransfers(namespace, params)
+	xfers, err := repo.getTransfers(namespace, params)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/transfers/router.go
+++ b/pkg/transfers/router.go
@@ -39,8 +39,8 @@ type Router struct {
 
 	LimitChecker limiter.Checker
 
-	GetUserTransfers   http.HandlerFunc
-	CreateUserTransfer http.HandlerFunc
+	GetTransfers       http.HandlerFunc
+	CreateTransfer     http.HandlerFunc
 	GetUserTransfer    http.HandlerFunc
 	DeleteUserTransfer http.HandlerFunc
 }
@@ -66,16 +66,16 @@ func NewRouter(
 		Repo:      repo,
 		Publisher: pub,
 
-		GetUserTransfers:   GetUserTransfers(cfg, repo),
-		CreateUserTransfer: CreateUserTransfer(cfg, repo, namespaceRepo, customersClient, accountDecryptor, fundStrategy, pub, limitChecker),
+		GetTransfers:       GetTransfers(cfg, repo),
+		CreateTransfer:     CreateTransfer(cfg, repo, namespaceRepo, customersClient, accountDecryptor, fundStrategy, pub, limitChecker),
 		GetUserTransfer:    GetUserTransfer(cfg, repo),
 		DeleteUserTransfer: DeleteUserTransfer(cfg, repo, pub),
 	}
 }
 
 func (c *Router) RegisterRoutes(r *mux.Router) {
-	r.Methods("GET").Path("/transfers").HandlerFunc(c.GetUserTransfers)
-	r.Methods("POST").Path("/transfers").HandlerFunc(c.CreateUserTransfer)
+	r.Methods("GET").Path("/transfers").HandlerFunc(c.GetTransfers)
+	r.Methods("POST").Path("/transfers").HandlerFunc(c.CreateTransfer)
 	r.Methods("GET").Path("/transfers/{transferID}").HandlerFunc(c.GetUserTransfer)
 	r.Methods("DELETE").Path("/transfers/{transferID}").HandlerFunc(c.DeleteUserTransfer)
 }
@@ -127,12 +127,12 @@ func readTransferFilterParams(r *http.Request) transferFilterParams {
 	return params
 }
 
-func GetUserTransfers(cfg *config.Config, repo Repository) http.HandlerFunc {
+func GetTransfers(cfg *config.Config, repo Repository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		responder := route.NewResponder(cfg, w, r)
 
 		params := readTransferFilterParams(r)
-		xfers, err := repo.getUserTransfers(responder.Namespace, params)
+		xfers, err := repo.getTransfers(responder.Namespace, params)
 		if err != nil {
 			responder.Problem(err)
 			return
@@ -145,7 +145,7 @@ func GetUserTransfers(cfg *config.Config, repo Repository) http.HandlerFunc {
 	}
 }
 
-func CreateUserTransfer(
+func CreateTransfer(
 	cfg *config.Config,
 	repo Repository,
 	namespaceRepo namespace.Repository,


### PR DESCRIPTION
After we removed x-user-id it makes sense to just call it "get transfers."