### PR TITLE
set companyid using org config as first option

### DIFF
--- a/pkg/transfers/router.go
+++ b/pkg/transfers/router.go
@@ -224,7 +224,13 @@ func CreateTransfer(
 				return
 			}
 
-			companyID := cfg.ODFI.FileConfig.BatchHeader.CompanyIdentification // TODO(adam): this will also be read from auth on the request
+			var companyID string
+			orgConfig, err := orgRepo.GetConfig(responder.OrganizationID)
+			if err == nil && orgConfig != nil {
+				companyID = orgConfig.CompanyIdentification
+			}else {
+				companyID = cfg.ODFI.FileConfig.BatchHeader.CompanyIdentification // TODO(adam): this will also be read from auth on the request
+			}
 
 			files, err := fundStrategy.Originate(companyID, transfer, source, destination)
 			if err != nil {

--- a/pkg/transfers/router.go
+++ b/pkg/transfers/router.go
@@ -228,7 +228,7 @@ func CreateTransfer(
 			orgConfig, err := orgRepo.GetConfig(responder.OrganizationID)
 			if err == nil && orgConfig != nil {
 				companyID = orgConfig.CompanyIdentification
-			}else {
+			} else {
 				companyID = cfg.ODFI.FileConfig.BatchHeader.CompanyIdentification // TODO(adam): this will also be read from auth on the request
 			}
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/moov-io/paygate/issues/580. We need to set the `CompanyIdentification` if the organization has it configured or we use the default file based config.