### PR TITLE
transfers/pipeline: break out of async loop on Subscription shutdown

### DIFF
--- a/pkg/transfers/pipeline/aggregate.go
+++ b/pkg/transfers/pipeline/aggregate.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"strings"
 	"time"
 
 	"github.com/moov-io/ach"
@@ -271,6 +272,11 @@ func (xfagg *XferAggregator) await() chan error {
 		msg, err := xfagg.subscription.Receive(context.Background())
 		if err != nil {
 			xfagg.logger.LogErrorf("ERROR receiving message: %v", err)
+
+			if strings.Contains(err.Error(), "has been Shutdown") {
+				// quit the infinite loop if it has been shutdown
+				return
+			}
 		}
 		out <- handleMessage(xfagg.merger, msg)
 	}()


### PR DESCRIPTION
This was reported by a community member where on shutdown the log is
filled with "FailedPrecondition" messages as this loop keeps iterating
until the underlying process is killed.