### PR TITLE
Fixing the example config to work with the docker-compose sftp container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,9 @@ services:
     ports:
       - "2222:22"
     volumes:
-      - "./testdata/sftp-server:/home/demo/upload"
+      - "./testdata/sftp-server:/home/demo"
     command:
-      - "demo:password:::upload"
+      - "demo:password:::"
   smtp:
     image: oryd/mailslurper:latest-smtps
     ports:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -40,7 +40,7 @@ odfi:
     username: "admin"
     password: "123456"
   # sftp:
-  #   hostname: "localhost:2222"
+  #   hostname: "sftp:22"
   #   username: "demo"
   #   password: "password"
   storage:


### PR DESCRIPTION
Fixes the commented out sftp example config to work when running along docker-compose.