### PR TITLE
Add diffie-hellman-group-exchange-sha256 to resolve sftp handshake failed

### DIFF
--- a/pkg/upload/sftp.go
+++ b/pkg/upload/sftp.go
@@ -107,7 +107,14 @@ func sftpConnect(logger log.Logger, cfg config.ODFI) (*ssh.Client, io.WriteClose
 		return nil, nil, nil, errors.New("nil config or sftp config")
 	}
 
+	sshConf := ssh.Config{}
+	sshConf.SetDefaults()
+	sshConf.KeyExchanges = append(
+		sshConf.KeyExchanges,
+		"diffie-hellman-group-exchange-sha256",
+	)
 	conf := &ssh.ClientConfig{
+		Config:  sshConf,
 		User:    cfg.SFTP.Username,
 		Timeout: cfg.SFTP.Timeout(),
 	}


### PR DESCRIPTION
Resolves on master
`ssh: handshake failed: ssh: no common algorithm for key exchange; client offered: [curve25519-sha256@libssh.org ecdh-sha2-nistp256 ecdh-sha2-nistp384 ecdh-sha2-nistp521 diffie-hellman-group14-sha1], server offered: [diffie-hellman-group-exchange-sha256]"`
#625 