### PR TITLE
schedule: include timezone in cutoff start/end logging

### DIFF
--- a/pkg/transfers/pipeline/aggregate.go
+++ b/pkg/transfers/pipeline/aggregate.go
@@ -198,7 +198,8 @@ func (xfagg *XferAggregator) manualCutoff(waiter manuallyTriggeredCutoff) {
 
 func (xfagg *XferAggregator) withEachFile(when time.Time) {
 	window := when.Format("15:04")
-	xfagg.logger.Logf("starting %s cutoff window processing", window)
+	tzname, _ := when.Zone()
+	xfagg.logger.Logf("starting %s %s cutoff window processing", window, tzname)
 
 	if processed, err := xfagg.merger.WithEachMerged(xfagg.runTransformers); err != nil {
 		xfagg.logger.LogErrorf("ERROR inside WithEachMerged: %v", err)
@@ -208,7 +209,7 @@ func (xfagg *XferAggregator) withEachFile(when time.Time) {
 		}
 	}
 
-	xfagg.logger.Logf("ended %s cutoff window processing", window)
+	xfagg.logger.Logf("ended %s %s cutoff window processing", window, tzname)
 }
 
 func (xfagg *XferAggregator) uploadFile(res *transform.Result) error {

--- a/x/schedule/cutoff.go
+++ b/x/schedule/cutoff.go
@@ -49,7 +49,7 @@ func (ct *CutoffTimes) Stop() {
 func (ct *CutoffTimes) maybeTick(location *time.Location) {
 	now := base.Now(location)
 	if !now.IsWeekend() && now.IsBankingDay() {
-		ct.C <- now.Time.In(time.Local)
+		ct.C <- now.Time
 	}
 }
 


### PR DESCRIPTION
Example: 

```
ts=2021-02-11T00:04:00Z msg="starting 19:04 EST cutoff window processing" level=info package=main service=XferAggregator
ts=2021-02-11T00:04:00Z msg="wrote 0 files" level=info package=main
ts=2021-02-11T00:04:00Z msg="ended 19:04 EST cutoff window processing" level=info package=main service=XferAggregator
```