### PR TITLE
Allowing processor to handle files downloaded to root of temp dir

### DIFF
--- a/pkg/transfers/inbound/processor_test.go
+++ b/pkg/transfers/inbound/processor_test.go
@@ -21,7 +21,7 @@ func TestProcessor__process(t *testing.T) {
 	// By reading a file without ACH FileHeaders we still want to try and process
 	// Batches inside of it if any are found, so reading this kind of file shouldn't
 	// return an error from reading the file.
-	if err := process(dir, processors); err != nil {
+	if err := ProcessFiles(&downloadedFiles{dir: dir}, processors); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
The `ProcessFile` function assumes all children of `downloadedFiles.dir` are directories. This PR no longer makes that assumption by checking if it is a file or dir and handling accordingly.