### PR TITLE
transfers/fundflow: set EffectiveEntryDate for +2 days after last cutoff window

### DIFF
--- a/pkg/achx/batch.go
+++ b/pkg/achx/batch.go
@@ -54,7 +54,7 @@ func makeBatchHeader(id string, options Options, xfer *client.Transfer, source S
 		batchHeader.CompanyDescriptiveDate = now.Format("060102")
 	}
 
-	batchHeader.EffectiveEntryDate = base.NewTime(now).AddBankingDay(1).Format("060102") // Date to be posted, YYMMDD
+	batchHeader.EffectiveEntryDate = options.EffectiveEntryDate.Format("060102") // Date to be posted, YYMMDD
 	batchHeader.ODFIIdentification = ABA8(options.ODFIRoutingNumber)
 
 	return batchHeader

--- a/pkg/achx/files.go
+++ b/pkg/achx/files.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/moov-io/ach"
+	"github.com/moov-io/base"
 	customers "github.com/moov-io/customers/pkg/client"
 	"github.com/moov-io/paygate/pkg/client"
 	"github.com/moov-io/paygate/pkg/config"
@@ -33,10 +34,11 @@ type Destination struct {
 }
 
 type Options struct {
-	ODFIRoutingNumber string
-	Gateway           config.Gateway
-	FileConfig        config.FileConfig
-	CutoffTimezone    *time.Location
+	ODFIRoutingNumber  string
+	Gateway            config.Gateway
+	FileConfig         config.FileConfig
+	CutoffTimezone     *time.Location
+	EffectiveEntryDate base.Time
 
 	// CompanyIdentification is a string passed through to the Batch Header.
 	// This value can be set from auth on the request and has a fallback from

--- a/pkg/transfers/fundflow/first_party_test.go
+++ b/pkg/transfers/fundflow/first_party_test.go
@@ -140,15 +140,27 @@ func TestCalculateEffectiveEntryDate(t *testing.T) {
 	now, _ := time.Parse("2006-01-02 15:04", "2021-04-19 10:00") // layout, value
 	timeService.Change(now.In(loc))
 
-	effective := calculateEffectiveEntryDate(cfg, timeService)
+	effective := calculateEffectiveEntryDate(cfg, timeService, false)
 	if v := effective.String(); v != "2021-04-20 10:00:00 +0000 UTC" {
+		t.Error(v)
+	}
+
+	// same-day ACH settles today
+	effective = calculateEffectiveEntryDate(cfg, timeService, true)
+	if v := effective.String(); v != "2021-04-19 10:00:00 +0000 UTC" {
 		t.Error(v)
 	}
 
 	// advance our timeService
 	timeService.Add(5 * time.Hour)
-	effective = calculateEffectiveEntryDate(cfg, timeService)
+	effective = calculateEffectiveEntryDate(cfg, timeService, false)
 	if v := effective.String(); v != "2021-04-21 15:00:00 +0000 UTC" {
+		t.Error(v)
+	}
+
+	// same day transfers are always the next day
+	effective = calculateEffectiveEntryDate(cfg, timeService, true)
+	if v := effective.String(); v != "2021-04-20 15:00:00 +0000 UTC" {
 		t.Error(v)
 	}
 }


### PR DESCRIPTION
<img width="1060" alt="Screen Shot 2021-04-19 at 11 24 33 AM" src="https://user-images.githubusercontent.com/120951/115284682-d6758f80-a101-11eb-89e0-37ec926333fd.png">
