### PR TITLE
transfers/pipeline: fix kafka subscription

### DIFF
--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -1,0 +1,93 @@
+version: '3'
+services:
+  customers:
+    image: moov/customers:v0.5.0-dev31
+    ports:
+      - '8087:8087'
+      - '9097:9097'
+    environment:
+      FED_ENDPOINT: 'http://fed:8086'
+      # The transit key matches customers.accounts.decryptor.symmetric.keyURI in examples/config.yaml
+      TRANSIT_LOCAL_BASE64_KEY: 'base64key://MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI='
+      PAYGATE_ENDPOINT: 'http://paygate:8082'
+      WATCHMAN_ENDPOINT: 'http://watchman:8084'
+    depends_on:
+      - fed
+      # - paygate
+      - watchman
+  fed:
+    image: moov/fed:v0.6.0
+    ports:
+      - '8086:8086'
+      - '9096:9096'
+    environment:
+      FEDACH_DATA_PATH: './data/fed/FedACHdir.txt'
+      FEDWIRE_DATA_PATH: './data/fed/fpddir.txt'
+  watchman:
+    image: moov/watchman:static
+    ports:
+      - '8084:8084'
+      - '9094:9094'
+  ftp:
+    image: moov/fsftp:v0.2.0
+    ports:
+      - '2121:2121'
+      - '30000-30009:30000-30009'
+    volumes:
+      - './testdata/ftp-server:/data'
+    command:
+      - '-host=0.0.0.0'
+      - '-root=/data'
+      - '-user=admin'
+      - '-pass=123456'
+      - '-passive-ports=30000-30009'
+  sftp:
+    image: atmoz/sftp:latest
+    ports:
+      - '2222:22'
+    volumes:
+      - './testdata/sftp-server:/home/demo'
+    command:
+      - 'demo:password:::'
+  smtp:
+    image: oryd/mailslurper:latest-smtps
+    ports:
+      - '1025:1025'
+      - '4444:4436'
+      - '4445:4437'
+  paygate:
+    build: .
+    ports:
+      - '8082:8082'
+      - '9092:9092'
+    command: ['-config=/conf/kafka.yaml']
+    volumes:
+      - './examples/:/conf/'
+    environment:
+      CUSTOMERS_ENDPOINT: 'http://customers:8087'
+    depends_on:
+      - customers
+      - kafka # might need to add a wait-for kafka to reliably docker-compose up
+  zookeeper:
+    image: confluentinc/cp-zookeeper:6.2.0
+    ports:
+      - '2181:2181'
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+  kafka:
+    image: confluentinc/cp-kafka:6.2.0
+    ports:
+      - '9095:9092'
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-5:9091,LISTENER_LOCAL://localhost:29095'
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9095
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+    depends_on:
+      - zookeeper
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/examples/kafka.yaml
+++ b/examples/kafka.yaml
@@ -1,0 +1,83 @@
+logging:
+  format: "plain"
+customers:
+  endpoint: "http://customers:8087"
+  accounts:
+    decryptor:
+      symmetric:
+        # INSECURE KEY -- Do not use in production!
+        keyURI: 'base64key://MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI='
+  debug: false
+database:
+  sqlite:
+    path: "paygate.db"
+odfi:
+  routingNumber: "221475786"
+  gateway:
+    # origin is often an ABA routing number
+    origin: "221475786"
+    # origin_name is the name of your ODFI
+    originName: "Teachers FCU"
+    # destination can be the ABA routing number of the Federal Reserve bank used
+    destination: "071000301"
+    # destination_name would be name of Federal Reserve bank used
+    destinationName: "FRBATLANTA"
+  inboundPath: "./inbound/"
+  outboundPath: "./outbound/"
+  returnPath: "./returned/"
+  cutoffs:
+    timezone: "America/New_York"
+    windows:
+      - "16:20" # 4:20pm EST
+  inbound:
+    interval: "10m"
+  fileConfig:
+    batchHeader:
+      companyIdentification: "MoovZZZZZZ"
+    balanceEntries: true
+  ftp:
+    hostname: "ftp:2121"
+    username: "admin"
+    password: "123456"
+  # sftp:
+  #   hostname: "sftp:22"
+  #   username: "demo"
+  #   password: "password"
+  storage:
+    cleanupLocalDirectory: true
+    keepRemoteFiles: false
+    removeZeroByteFilesAfter: 10m
+    local:
+      directory: "./storage/"
+transfers:
+  limits:
+    fixed:
+      softLimit: 500000  #  $5,000.00
+      hardLimit: 1000000 # $10,000.00
+validation:
+  microDeposits:
+    source:
+      customerID: "replace-me"
+      accountID: "replace-me"
+      organization: "replace-me"
+pipeline:
+  merging:
+    directory: "/storage/"
+    flattenBatches:
+      enable: true
+  output:
+    format: "nacha"
+  stream:
+    kafka:
+      brokers:
+        - 'kafka:9095'
+      topic: paygate
+      group: paygate-group
+  notifications:
+    email:
+      from: "noreply@moov.io"
+      to:
+        - "jane@moov.io"
+        - "john@moov.io"
+      connectionURI: "smtps://test:test@localhost:1025/?insecure_skip_verify=true"
+      companyName: "Moov"

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -33,10 +33,6 @@ func Subscription(ctx context.Context, url string) (*pubsub.Subscription, error)
 // KafkaTopic creates a pubsub.Topic that sends to a Kafka topic. It uses a sarama.SyncProducer to send messages.
 // Producer options can be configured in the Producer section of the sarama.Config: https://godoc.org/github.com/Shopify/sarama#Config.
 func KafkaTopic(brokers []string, config *sarama.Config, topicName string, opts *kafkapubsub.TopicOptions) (*pubsub.Topic, error) {
-	if config != nil {
-		// From the kafkapubsub docs: "Config.Producer.Return.Success must be set to true"
-		config.Producer.Return.Successes = true
-	}
 	return kafkapubsub.OpenTopic(brokers, config, topicName, opts)
 }
 

--- a/pkg/transfers/pipeline/publisher_kafka.go
+++ b/pkg/transfers/pipeline/publisher_kafka.go
@@ -10,7 +10,7 @@ import (
 	"github.com/moov-io/paygate/pkg/config"
 	"github.com/moov-io/paygate/pkg/stream"
 
-	"github.com/Shopify/sarama"
+	"gocloud.dev/pubsub/kafkapubsub"
 )
 
 func createKafkaPublisher(cfg *config.KafkaPipeline) (*streamPublisher, error) {
@@ -21,7 +21,9 @@ func createKafkaPublisher(cfg *config.KafkaPipeline) (*streamPublisher, error) {
 	pub := &streamPublisher{}
 	var err error
 
-	config := sarama.NewConfig()
+	// kafkapubsub.MinimalConfig returns a minimal sarama.Config required for kafkapubsub
+	config := kafkapubsub.MinimalConfig()
+
 	pub.topic, err = stream.KafkaTopic(cfg.Brokers, config, cfg.Topic, nil)
 
 	return pub, err

--- a/pkg/transfers/pipeline/subscription.go
+++ b/pkg/transfers/pipeline/subscription.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moov-io/paygate/pkg/config"
 	"github.com/moov-io/paygate/pkg/stream"
 	"gocloud.dev/pubsub"
+	"gocloud.dev/pubsub/kafkapubsub"
 )
 
 func NewSubscription(cfg *config.Config) (*pubsub.Subscription, error) {
@@ -28,9 +29,20 @@ func createStreamSubscription(cfg *config.StreamPipeline) (*pubsub.Subscription,
 	if cfg.InMem != nil {
 		return createInmemSubscription(cfg.InMem.URL)
 	}
+	if cfg.Kafka != nil {
+		return createKafkaSubscription(cfg.Kafka)
+	}
+
 	return nil, fmt.Errorf("unknown %#v", cfg)
 }
 
 func createInmemSubscription(url string) (*pubsub.Subscription, error) {
 	return stream.Subscription(context.TODO(), url)
+}
+
+func createKafkaSubscription(cfg *config.KafkaPipeline) (*pubsub.Subscription, error) {
+	// kafkapubsub.MinimalConfig returns a minimal sarama.Config required for kafkapubsub
+	config := kafkapubsub.MinimalConfig()
+
+	return stream.KafkaSubscription(cfg.Brokers, config, cfg.Group, []string{cfg.Topic}, nil)
 }


### PR DESCRIPTION
PayGate Version: v0.10.2

What were you trying to do?
Add Kafka stream configuration.

What did you expect to see?
paygate to use the given kafka configuration without error

What did you see?
```
panic: ERROR setting up transfer subscription: unknown &config.StreamPipeline{InMem:(*config.InMemPipeline)(nil), Kafka:(*config.KafkaPipeline)(0xc000528f00)}
goroutine 1 [running]:
main.main()
	/go/src/github.com/moov-io/paygate/cmd/server/main.go:116 +0x2097
```

How can we reproduce the problem?
the docker-compose file from the PR running paygate 0.10.2